### PR TITLE
Refactor common attributes and methods to ModelBase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __pycache__
 */cython_version.py
 htmlcov
 .coverage
+coverage.xml
 MANIFEST
 .ipynb_checkpoints
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -21,7 +21,7 @@ python:
     - requirements: docs/requirements.txt
     - method: pip
       path: .
-      extra_requirements:
-        - docs
-        - all
+# Build from requirements.txt to use https://github.com/astropy/sphinx-automodapi/pull/121
+#      extra_requirements:
+#        - docs
   system_packages: true

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,12 @@ extensions = [
 ]
 numpydoc_show_class_members = False
 nbsphinx_execute = 'never'
+all_methods = [
+    'mcalf.models.base.ModelBase',
+    'mcalf.models.ModelBase',
+]
+automodsumm_private_methods_of = all_methods
+automodsumm_special_methods_of = all_methods
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.coverage',
     'sphinx.ext.inheritance_diagram',
+    'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax',
     'sphinx.ext.napoleon',
     'sphinx.ext.todo',
@@ -64,6 +65,14 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+intersphinx_mapping = {
+    "python": ('https://docs.python.org/3', None),
+    "astropy": ("https://docs.astropy.org/en/stable/", None),
+    "matplotlib": ('https://matplotlib.org/', None),
+    "numpy": ('https://numpy.org/doc/stable', None),
+    "scipy": ('https://docs.scipy.org/doc/scipy/reference', None),
+    "sklearn": ('https://scikit-learn.org/stable', None),
+}
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 sphinx==3.1.2
-sphinx-automodapi==0.12
+#sphinx-automodapi==0.12
+-e git+https://github.com/astropy/sphinx-automodapi.git@refs/pull/121/head#egg=sphinx-automodapi
 ipykernel
 nbsphinx==0.7.1
 sphinx-rtd-theme==0.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,10 @@ docs =
 [options.packages.find]
 where = src
 
+[tool:pytest]
+filterwarnings =
+    ignore:Spectra should be fully processed before loading into MCALF.
+
 [coverage:run]
 omit =
   */mcalf/tests/*

--- a/src/mcalf/models/base.py
+++ b/src/mcalf/models/base.py
@@ -27,6 +27,14 @@ class ModelBase:
 
     Warning: This class should not be used directly.
     Use derived classes instead.
+
+    Parameters
+    ----------
+    ${PARAMETERS}
+
+    Attributes
+    ----------
+    ${ATTRIBUTES}
     """
     def __init__(self, config=None, **kwargs):
 
@@ -897,11 +905,12 @@ for k in [  # Remove some entries
     del BASE_ATTRIBUTES[k]
 BASE_ATTRIBUTES_STR = ''.join(BASE_ATTRIBUTES[i] for i in BASE_ATTRIBUTES)
 
-# Set the docstring
-ModelBase.__doc__ += """
-    Parameters
-    ----------""" + BASE_PARAMETERS_STR + """
-
-    Attributes
-    ----------""" + BASE_ATTRIBUTES_STR + """
-"""
+# Update the docstring with the generated strings
+ModelBase.__doc__ = ModelBase.__doc__.replace(
+    '${PARAMETERS}',
+    BASE_PARAMETERS_STR.lstrip()
+)
+ModelBase.__doc__ = ModelBase.__doc__.replace(
+    '${ATTRIBUTES}',
+    BASE_ATTRIBUTES_STR.lstrip()
+)

--- a/src/mcalf/models/base.py
+++ b/src/mcalf/models/base.py
@@ -25,8 +25,9 @@ __all__ = ['ModelBase', 'BASE_PARAMETERS', 'BASE_ATTRIBUTES']
 class ModelBase:
     """Base class for spectral line model fitting.
 
-    Warning: This class should not be used directly.
-    Use derived classes instead.
+    .. warning::
+        This class should not be used directly.
+        Use derived classes instead.
 
     Parameters
     ----------
@@ -128,7 +129,7 @@ class ModelBase:
         self.__stationary_line_core = wavelength
 
     def _set_prefilter(self):
-        """Set the `prefilter_response` parameter
+        """Set the `prefilter_response` parameter.
 
         This method should be called in a child class once `stationary_line_core` has been set.
         """
@@ -149,7 +150,7 @@ class ModelBase:
                 raise ValueError("prefilter_response array must be the same length as constant_wavelengths array")
 
     def _validate_base_attributes(self):
-        """Validate some of the object's attributes
+        """Validate some of the object's attributes.
 
         Raises
         ------
@@ -173,22 +174,23 @@ class ModelBase:
     def _load_data(self, array, names=None, target=None):
         """Load a specified array into the model object.
 
-        Load `array` with dimension names `names` into the parameter specified by `target`.
+        Load `array` with dimension names `names` into the attribute specified by `target`.
 
         Parameters
         ----------
-        array : ndarray
+        array : numpy.ndarray
             The array to load.
 
-        names : list of str, length = `array.ndims`
+        names : list of str, length=`array.ndim`
             List of dimension names for `array`. Valid dimension names depend on `target`.
 
         target : {'array', 'background'}
+            The attribute to load the `array` into.
 
         See Also
         --------
-        load_array : Load and array of spectra
-        load_background : Load an array of spectral backgrounds
+        load_array : Load and array of spectra.
+        load_background : Load an array of spectral backgrounds.
         """
 
         # Validate specified `target`
@@ -216,7 +218,7 @@ class ModelBase:
 
         # Define the transposition on the input array to get the dimensions in order
         #     ['time', 'row', 'column'(, 'wavelength')]
-        n_dims = 4 if target == 'array' else 3  # ndims of (padded) array to load data into
+        n_dims = 4 if target == 'array' else 3  # ndim of (padded) array to load data into
         transposition = [None] * n_dims
         for i in range(len(names)):
             if names[i] == 'time':
@@ -270,16 +272,16 @@ class ModelBase:
 
         Parameters
         ----------
-        array : ndarray of ndims > 1
+        array : numpy.ndarray, ndim>1
             An array containing at least two spectra.
 
-        names : list of str, length = `array.ndims`
+        names : list of str, length=`array.ndim`
             List of dimension names for `array`. Valid dimension names are 'time', 'row', 'column' and 'wavelength'.
             'wavelength' is a required dimension.
 
         See Also
         --------
-        load_background : Load an array of spectral backgrounds
+        load_background : Load an array of spectral backgrounds.
         """
         self._load_data(array, names=names, target='array')
 
@@ -290,33 +292,33 @@ class ModelBase:
 
         Parameters
         ----------
-        array : ndarray of ndim>0
+        array : numpy.ndarray, ndim>0
             An array containing at least two backgrounds.
 
-        names : list of str, length = `array.ndims`
+        names : list of str, length=`array.ndim`
             List of dimension names for `array`. Valid dimension names are 'time', 'row' and 'column'.
 
         See Also
         --------
-        load_array : Load and array of spectra
+        load_array : Load and array of spectra.
         """
         self._load_data(array, names=names, target='background')
 
     def train(self, X, y):
         """Fit the neural network model to spectra matrix X and spectra labels y.
 
-        Calls the `fit` method on the `neural_network` parameter of the model object.
+        Calls the :meth:`fit` method on the `neural_network` parameter of the model object.
 
         Parameters
         ----------
-        X : ndarray or sparse matrix of shape (n_spectra, n_wavelengths)
+        X : numpy.ndarray or sparse matrix, shape=(n_spectra, n_wavelengths)
             The input spectra.
-        y : ndarray of shape (n_spectra,) or (n_spectra, n_outputs)
+        y : numpy.ndarray, shape= (n_spectra,) or (n_spectra, n_outputs)
             The target class labels.
 
         See Also
         --------
-        test : Test how well the neural network has been trained
+        test : Test how well the neural network has been trained.
         """
         self.neural_network.fit(X, y)
 
@@ -324,23 +326,25 @@ class ModelBase:
         """Test the accuracy of the trained neural network.
 
         Prints a table of results showing:
-            1) the percentage of predictions that equal the target labels;
-            2) the average classification deviation and standard deviation from the ground truth classification
-                for each labelled classification;
-            3) the average classification deviation and standard deviation overall.
-        If the model object has an output parameter, it will create a CSV file (`self.output`/neural_network/test.csv)
+
+        1) the percentage of predictions that equal the target labels;
+        2) the average classification deviation and standard deviation from the ground truth classification
+           for each labelled classification;
+        3) the average classification deviation and standard deviation overall.
+
+        If the model object has an output parameter, it will create a CSV file (``output``/neural_network/test.csv)
         listing the predictions and ground truth data.
 
         Parameters
         ----------
-        X : ndarray or sparse matrix of shape (n_spectra, n_wavelengths)
+        X : numpy.ndarray or sparse matrix, shape=(n_spectra, n_wavelengths)
             The input spectra.
-        y : ndarray of shape (n_spectra,) or (n_spectra, n_outputs)
+        y : numpy.ndarray, shape= (n_spectra,) or (n_spectra, n_outputs)
             The target class labels.
 
         See Also
         --------
-        train : Train the neural network
+        train : Train the neural network.
         """
         # Predict the labels
         try:
@@ -391,34 +395,34 @@ class ModelBase:
                        fmt='%3d', delimiter=',', header='ground_truth, prediction')
 
     def classify_spectra(self, time=None, row=None, column=None, spectra=None, only_normalise=False):
-        """Classify the specified spectra
+        """Classify the specified spectra.
 
         Will also normalise each spectrum such that its intensity will range from zero to one.
 
         Parameters
         ----------
         time : int or iterable, optional, default=None
-            The time index. The index can be either a single integer index or an iterable. E.g. a list, a NumPy
-            array, a Python range, etc. can be used.
+            The time index. The index can be either a single integer index or an iterable. E.g. a list,
+            a :class:`numpy.ndarray`, a Python range, etc. can be used.
         row : int or iterable, optional, default=None
             The row index. See comment for `time` parameter.
         column : int or iterable, optional, default=None
             The column index. See comment for `time` parameter.
-        spectra : ndarray, optional, default=None
+        spectra : numpy.ndarray, optional, default=None
             The explicit spectra to classify. If `only_normalise` is False, this must be 1D.
-        only_normalise : bool, optional, default = False
+        only_normalise : bool, optional, default=False
             Whether the single spectrum given  in `spectra` should not be interpolated and corrected.
 
         Returns
         -------
-        classifications : ndarray
+        classifications : numpy.ndarray
             Array of classifications with the same time, row and column indices as `spectra`.
 
         See Also
         --------
-        train : Train the neural network
-        test : Test the accuracy of the neural network
-        get_spectra : Get processed spectra from the objects `array` attribute
+        train : Train the neural network.
+        test : Test the accuracy of the neural network.
+        get_spectra : Get processed spectra from the objects `array` attribute.
         """
         if not only_normalise:  # Get the spectrum, otherwise use the provided one directly
             spectra = self.get_spectra(time=time, row=row, column=column, spectrum=spectra)
@@ -445,7 +449,7 @@ class ModelBase:
         return classifications
 
     def _get_time_row_column(self, time=None, row=None, column=None):
-        """Validate and infer the time, row and column index
+        """Validate and infer the time, row and column index.
 
         Takes any time, row and column index given and if any are not specified, they are returned as 0 if the
         spectral array only has one value at its dimension. If there are multiple and no index is specified,
@@ -471,12 +475,12 @@ class ModelBase:
 
         See Also
         --------
-        utils.make_iter : Make a variable iterable
+        mcalf.utils.make_iter : Make a variable iterable.
 
         Notes
         -----
         No type checking is done on the input indices so it can be anything but in most cases will need to be
-        either an integer or iterable. The `utils.make_iter` function can be used to make indices iterable.
+        either an integer or iterable. The :func:`mcalf.utils.make_iter` function can be used to make indices iterable.
         """
         array_shape = np.shape(self.array)
         if time is None:
@@ -498,7 +502,7 @@ class ModelBase:
         return time, row, column
 
     def get_spectra(self, time=None, row=None, column=None, spectrum=None, correct=True, background=False):
-        """Gets corrected spectra from the spectral array
+        """Gets corrected spectra from the spectral array.
 
         Takes either a set of indices or an explicit spectrum and optionally applied corrections and background
         removal.
@@ -506,8 +510,8 @@ class ModelBase:
         Parameters
         ----------
         time : int or iterable, optional, default=None
-            The time index. The index can be either a single integer index or an iterable. E.g. a list, a NumPy
-            array, a Python range, etc. can be used.
+            The time index. The index can be either a single integer index or an iterable. E.g. a list,
+            a :class:`numpy.ndarray`, a Python range, etc. can be used.
         row : int or iterable, optional, default=None
             The row index. See comment for `time` parameter.
         column : int or iterable, optional, default=None
@@ -552,36 +556,37 @@ class ModelBase:
         return spectra
 
     def _fit(self, spectrum, classification=None, spectrum_index=None):
-        """Fit a single spectrum for the given profile or classification
+        """Fit a single spectrum for the given profile or classification.
 
-        This call signature and docstring specifies how the `_fit` method must be implemented in
-        each subclass of `ModelBase`.
+        .. warning::
+            This call signature and docstring specify how the `_fit` method must be implemented in
+            each subclass of `ModelBase`. **It is not implemented in this class.**
 
         Parameters
         ----------
         spectrum : numpy.ndarray, ndim=1, length=n_constant_wavelengths
             The spectrum to be fitted.
-        classification : int, optional, default = None
+        classification : int, optional, default=None
             Classification to determine the fitted profile to use.
-        spectrum_index : array_like or list or tuple, length=3, optional, default = None
+        spectrum_index : array_like or list or tuple, length=3, optional, default=None
             The [time, row, column] index of the `spectrum` provided. Only used for error reporting.
 
         Returns
         -------
-        result : FitResult
-            Outcome of the fit returned in a FitResult object
+        result : mcalf.models.FitResult
+            Outcome of the fit returned in a :class:`mcalf.models.FitResult` object.
 
         See Also
         --------
-        fit : The recommended method for fitting spectra
-        FitResult : The object that the fit method returns
+        fit : The recommended method for fitting spectra.
+        mcalf.models.FitResult : The object that the fit method returns.
 
         Notes
         -----
-        This method is called for each requested spectrum by the `models.ModelBase.fit` method.
+        This method is called for each requested spectrum by the :meth:`models.ModelBase.fit` method.
         This is where most of the adjustments to the fitting method should be made. See other
         subclasses of `models.ModelBase` for examples of how to implement this method in a
-        new subclass. See `models.ModelBase.fit` for more information on how this method is
+        new subclass. See :meth:`models.ModelBase.fit` for more information on how this method is
         called.
         """
         raise NotImplementedError("The `_fit` method must be implemented in a subclass of `ModelBase`."
@@ -589,29 +594,30 @@ class ModelBase:
 
     def fit(self, time=None, row=None, column=None, spectrum=None, classifications=None,
             background=None, n_pools=None, **kwargs):
-        """Fits the model to specified spectra
+        """Fits the model to specified spectra.
 
         Fits the model to an array of spectra using multiprocessing if requested.
 
         Parameters
         ----------
-        time : int or iterable, optional, default = None
-            The time index. The index can be either a single integer index or an iterable. E.g. a list, a NumPy
-            array, a Python range, etc. can be used.
-        row : int or iterable, optional, default = None
+        time : int or iterable, optional, default=None
+            The time index. The index can be either a single integer index or an iterable. E.g. a list,
+            :class:`numpy.ndarray`, a Python range, etc. can be used.
+        row : int or iterable, optional, default=None
             The row index. See comment for `time` parameter.
-        column : int or iterable, optional, default = None
+        column : int or iterable, optional, default=None
             The column index. See comment for `time` parameter.
-        spectrum : numpy.ndarray, ndim=1, optional, default = None
+        spectrum : numpy.ndarray, ndim=1, optional, default=None
             The explicit spectrum to fit the model to.
-        classifications : int or array_like, optional, default = None
+        classifications : int or array_like, optional, default=None
             Classifications to determine the fitted profile to use. Will use neural network to classify them if not.
             If a multidimensional array, must have the same shape as [`time`, `row`, `column`].
             Dimensions that would have length of 1 can be excluded.
-        background : float, optional, default = None
+        background : float, optional, default=None
             If provided, this value will be subtracted from the explicit spectrum provided in `spectrum`. Will
-            not be applied to spectra found from the indices, use the `load_background` method instead.
-        n_pools : int, optional, default = None
+            not be applied to spectra found from the indices, use the :meth:`~mcalf.models.ModelBase.load_background`
+            method instead.
+        n_pools : int, optional, default=None
             The number of processing pools to calculate the fitting over. This allocates the fitting of different
             spectra to `n_pools` separate worker processes. When processing a large number of spectra this will make
             the fitting process take less time overall. It also distributes such that each worker process has the
@@ -620,12 +626,12 @@ class ModelBase:
             the evaluation over separate processes. If `n_pools` is not an integer greater than zero, it will fit
             the spectrum with a for loop.
         **kwargs : dictionary, optional
-            Extra keyword arguments to pass to `_fit`.
+            Extra keyword arguments to pass to :meth:`~mcalf.models.ModelBase._fit`.
 
         Returns
         -------
-        result : list of FitResult, length=n_spectra
-            Outcome of the fits returned as a list of FitResult objects
+        result : list of :class:`~mcalf.models.FitResult`, length=n_spectra
+            Outcome of the fits returned as a list of :class:`~mcalf.models.FitResult` objects.
         """
         # Specific fitting algorithm for IBIS Ca II 8542 Å
 
@@ -722,41 +728,42 @@ class ModelBase:
         return results
 
     def fit_spectrum(self, spectrum, **kwargs):
-        """Fits the specified spectrum array
+        """Fits the specified spectrum array.
 
-        Passes the spectrum argument to the fit method. For easily iterating over a list of spectra.
+        Passes the spectrum argument to the :meth:`~mcalf.models.ModelBase.fit` method.
+        For easily iterating over a list of spectra.
 
         Parameters
         ----------
-        spectrum : ndarray of ndim=1
+        spectrum : numpy.ndarray, ndim=1
             The explicit spectrum.
-        **kwargs : dictionary, optional
-            Extra keyword arguments to pass to fit.
+        **kwargs : dict, optional
+            Extra keyword arguments to pass to :meth:`~mcalf.models.ModelBase.fit`.
 
         Returns
         -------
-        result : FitResult
+        result : :class:`~mcalf.models.FitResult`
             Result of the fit.
 
         See Also
         --------
-        fit : General fitting method
+        fit : General fitting method.
         """
         return self.fit(spectrum=spectrum, **kwargs)
 
     def _curve_fit(self, model, spectrum, guess, sigma, bounds, x_scale, time=None, row=None, column=None):
-        """scipy.optimize.curve_fit wrapper with error handling
+        """:func:`scipy.optimize.curve_fit` wrapper with error handling.
 
-        Passes a certain set of parameters to the scipy.optimize.curve_fit function and catches some typical
+        Passes a certain set of parameters to the :func:`scipy.optimize.curve_fit` function and catches some typical
         errors, presenting a more specific warning message.
 
         Parameters
         ----------
         model : callable
-            The model function, f(x, …). It must take the `self.constant_wavelenghts` as the first argument and the
-            parameters to fit as separate remaining arguments.
+            The model function, f(x, …). It must take the `ModelBase.constant_wavelenghts` attribute
+            as the first argument and the parameters to fit as separate remaining arguments.
         spectrum : array_like
-            The dependent data, with length equal to that of `self.constant_wavelengths`.
+            The dependent data, with length equal to that of the `ModelBase.constant_wavelengths` attribute.
         guess : array_like, optional
             Initial guess for the parameters to fit.
         sigma : array_like
@@ -774,19 +781,20 @@ class ModelBase:
 
         Returns
         -------
-        fitted_parameters : ndarray, length=n_parameters
+        fitted_parameters : numpy.ndarray, length=n_parameters
             The parameters that recreate the model fitted to the spectrum.
         success : bool
             Whether the fit was successful or an error had to be handled.
 
         See Also
         --------
-        fit : General fitting method
-        fit_spectrum : Explicit spectrum fitting method
+        fit : General fitting method.
+        fit_spectrum : Explicit spectrum fitting method.
 
         Notes
         -----
-        More details can be found in the documentation for scipy.optimize.curve_fit and scipy.optimize.least_squares.
+        More details can be found in the documentation for :func:`scipy.optimize.curve_fit`
+        and :func:`scipy.optimize.least_squares`.
         """
         try:  # TODO Investigate if there is a performance gain to setting `check_finite` to False
 
@@ -830,58 +838,58 @@ DOCS['original_wavelengths'] = """
     original_wavelengths : array_like
         One-dimensional array of wavelengths that correspond to the uncorrected spectral data."""
 DOCS['stationary_line_core'] = """
-    stationary_line_core : float, optional, default = None
+    stationary_line_core : float, optional, default=None
         Wavelength of the stationary line core."""
 DOCS['neural_network'] = """
-    neural_network : optional, default = None
+    neural_network : optional, default=None
         The neural network classifier object that is used to classify spectra. This attribute should be set by a
-        child class of `mcalf.models.base.ModelBase`."""
+        child class of :class:`~mcalf.models.base.ModelBase`."""
 DOCS['constant_wavelengths'] = """
-    constant_wavelengths : array_like, ndim=1, optional, default = see description
+    constant_wavelengths : array_like, ndim=1, optional, default= see description
         The desired set of wavelengths that the spectral data should be rescaled to represent. It is assumed
         that these have constant spacing, but that may not be a requirement if you specify your own array.
         The default value is an array from the minimum to the maximum wavelength of `original_wavelengths` in
         constant steps of `delta_lambda`, overshooting the upper bound if the maximum wavelength has not been 
         reached."""
 DOCS['delta_lambda'] = """
-    delta_lambda : float, optional, default = 0.05
+    delta_lambda : float, optional, default=0.05
         The step used between each value of `constant_wavelengths` when its default value has to be calculated."""
 DOCS['sigma'] = """
-    sigma : optional, default = None
+    sigma : optional, default=None
         Sigma values used to weight the fit. This attribute should be set by a child class of 
-        `mcalf.models.base.ModelBase`."""
+        :class:`~mcalf.models.base.ModelBase`."""
 DOCS['prefilter_response'] = """
-    prefilter_response : array_like, length=n_wavelengths, optional, default = see note
+    prefilter_response : array_like, length=n_wavelengths, optional, default= see note
         Each constant wavelength scaled spectrum will be corrected by dividing it by this array. If `prefilter_response`
         is not given, and `prefilter_ref_main` and `prefilter_ref_wvscl` are not given, `prefilter_response` will have a
         default value of `None`."""
 DOCS['prefilter_ref_main'] = """
-    prefilter_ref_main : array_like, optional, default = None
+    prefilter_ref_main : array_like, optional, default= None
         If `prefilter_response` is not specified, this will be used along with `prefilter_ref_wvscl` to generate the
         default value of `prefilter_response`."""
 DOCS['prefilter_ref_wvscl'] = """
-    prefilter_ref_wvscl : array_like, optional, default = None
+    prefilter_ref_wvscl : array_like, optional, default=None
         If `prefilter_response` is not specified, this will be used along with `prefilter_ref_main` to generate the
         default value of `prefilter_response`."""
 DOCS['config'] = """
-    config : str, optional, default = None
+    config : str, optional, default=None
         Filename of a `.yml` file (relative to current directory) containing the initialising parameters for this
         object. Parameters provided explicitly to the object upon initialisation will override any provided in this
         file. All (or some) parameters that this object accepts can be specified in this file, except `neural_network`
         and `config`. Each line of the file should specify a different parameter and be formatted like
         `emission_guess: '[-inf, wl-0.15, 1e-6, 1e-6]'` or `original_wavelengths: 'original.fits'` for example.
         When specifying a string, use 'inf' to represent `np.inf` and 'wl' to represent `stationary_line_core` as shown.
-        If the string matches a file, `utils.load_parameter()` is used to load the contents of the file."""
+        If the string matches a file, :func:`mcalf.utils.load_parameter()` is used to load the contents of the file."""
 DOCS['output'] = """
-    output : str, optional, default = None
+    output : str, optional, default=None
         If the program wants to output data, it will place it relative to the location specified by this parameter.
         Some methods will only save data to a file if this parameter is not `None`. Such cases will be documented
         where relevant."""
 DOCS['array'] = """
-    array: ndarray, dimensions are['time', 'row', 'column', 'spectra']
+    array: numpy.ndarray, dimensions are ['time', 'row', 'column', 'spectra']
         Array holding spectra."""
 DOCS['background'] = """
-    background: ndarray, dimensions are['time', 'row', 'column']
+    background: numpy.ndarray, dimensions are ['time', 'row', 'column']
         Array holding spectral backgrounds."""
 
 # Form the parameter list

--- a/src/mcalf/models/base.py
+++ b/src/mcalf/models/base.py
@@ -150,9 +150,9 @@ class ModelBase:
         """
         # Wavelength arrays must be sorted ascending
         if np.sum(np.diff(self.original_wavelengths) > 0) < len(self.original_wavelengths) - 1:
-            raise ValueError("original_wavelength array must be sorted ascending")
+            raise ValueError("original_wavelengths array must be sorted ascending")
         if np.sum(np.diff(self.constant_wavelengths) > 0) < len(self.constant_wavelengths) - 1:
-            raise ValueError("constant_wavelength array must be sorted ascending")
+            raise ValueError("constant_wavelengths array must be sorted ascending")
 
         # Warn if the constant wavelengths extrapolate the original wavelengths
         if min(self.constant_wavelengths) - min(self.original_wavelengths) < -1e-6:
@@ -248,8 +248,6 @@ class ModelBase:
             self.array = ordered_array
         elif target == 'background':
             self.background = ordered_array
-        else:  # This should not happen
-            raise ValueError("unknown target (impossible error)")
 
         # If "the other array" has been loaded, warn the user if their dimensions are not compatible
         if self.array is not None and self.background is not None and \
@@ -668,9 +666,7 @@ class ModelBase:
             indices = indices[valid_spectra_i]
             classifications = classifications[valid_spectra_i]
 
-            if len(spectra) != len(indices) != len(classifications):  # Postprocessing sanity check
-                raise ValueError("number of spectra, number of recorded indices and number of classifications"
-                                 "are not the same (impossible error)")
+            assert len(spectra) == len(indices) == len(classifications)  # Postprocessing sanity check
 
             # Multiprocessing not required
             if n_pools is None or (isinstance(n_pools, (int, np.integer)) and n_pools <= 0):
@@ -685,8 +681,10 @@ class ModelBase:
 
                 # Define single argument function that can be evaluated in the pools
                 def func(data, kwargs=kwargs):
-                    spectrum, index, classification = data  # Extract data and pass to `_fit` method
-                    return self._fit(spectrum, classification=classification, spectrum_index=list(index), **kwargs)
+                    # Extract data and pass to `_fit` method
+                    spectrum, index, classification = data  # pragma: no cover
+                    return self._fit(spectrum, classification=classification,
+                                     spectrum_index=list(index), **kwargs)  # pragma: no cover
 
                 # Sort the arrays in descending classification order
                 s = np.argsort(classifications)[::-1]  # Classifications indices sorted in descending order

--- a/src/mcalf/models/base.py
+++ b/src/mcalf/models/base.py
@@ -383,6 +383,60 @@ class ModelBase:
             np.savetxt(os.path.join(self.output, "neural_network", "test.csv"), np.asarray([y, predictions]).T,
                        fmt='%3d', delimiter=',', header='ground_truth, prediction')
 
+    def classify_spectra(self, time=None, row=None, column=None, spectra=None, only_normalise=False):
+        """Classify the specified spectra
+
+        Will also normalise each spectrum such that its intensity will range from zero to one.
+
+        Parameters
+        ----------
+        time : int or iterable, optional, default=None
+            The time index. The index can be either a single integer index or an iterable. E.g. a list, a NumPy
+            array, a Python range, etc. can be used.
+        row : int or iterable, optional, default=None
+            The row index. See comment for `time` parameter.
+        column : int or iterable, optional, default=None
+            The column index. See comment for `time` parameter.
+        spectra : ndarray, optional, default=None
+            The explicit spectra to classify. If `only_normalise` is False, this must be 1D.
+        only_normalise : bool, optional, default = False
+            Whether the single spectrum given  in `spectra` should not be interpolated and corrected.
+
+        Returns
+        -------
+        classifications : ndarray
+            Array of classifications with the same time, row and column indices as `spectra`.
+
+        See Also
+        --------
+        train : Train the neural network
+        test : Test the accuracy of the neural network
+        get_spectra : Get processed spectra from the objects `array` attribute
+        """
+        if not only_normalise:  # Get the spectrum, otherwise use the provided one directly
+            spectra = self.get_spectra(time=time, row=row, column=column, spectrum=spectra)
+
+        # Vectorised normalisation for all spectra such that intensities for each spectrum is in range [0, 1]
+        spectra_list = spectra.reshape(-1, spectra.shape[-1]).T  # Reshape & transpose to (n_wavelengths, n_spectra)
+        spectra_list = spectra_list - spectra_list.min(axis=0)  # Subtract each spectrum's min value from itself (min 0)
+        spectra_list = spectra_list / spectra_list.max(axis=0)  # Divide each spectrum by its max value (min 0, max 1)
+        spectra_list = spectra_list.T  # Transpose to (n_spectra, n_wavelengths)
+
+        # Create the empty classifications array
+        classifications = np.full(len(spectra_list), -1, dtype=int)  # -1 reserved for invalid
+        valid_spectra_i = np.where(~np.isnan(spectra_list[:, 0]))  # Only predict the valid spectra
+        # Note: Spectra that have indices in the data but were masked or outside the field of view should be np.nan
+        try:
+            classifications[valid_spectra_i] = self.neural_network.predict(spectra_list[valid_spectra_i])
+        except NotFittedError:
+            raise NotFittedError("Neural network has not been trained yet. Call 'train' on the model class first.")
+        try:  # Try to give the classifications array the same indices as the spectral array
+            classifications = classifications.reshape(*spectra.shape[:-1])
+        except TypeError:  # 1D spectra array given
+            assert classifications.size == 1  # Verify
+
+        return classifications
+
     def _get_time_row_column(self, time=None, row=None, column=None):
         """Validate and infer the time, row and column index
 

--- a/src/mcalf/models/base.py
+++ b/src/mcalf/models/base.py
@@ -131,6 +131,11 @@ class ModelBase:
     def _set_prefilter(self):
         """Set the `prefilter_response` parameter.
 
+        .. deprecated:: 0.2
+             Prefilter response correction code, and `prefilter_response`, `prefilter_ref_main`
+             and `prefilter_ref_wvscl`, may be removed in a later release of MCALF.
+             Spectra should be fully processed before loading into MCALF.
+
         This method should be called in a child class once `stationary_line_core` has been set.
         """
         if self.prefilter_response is None:
@@ -139,10 +144,14 @@ class ModelBase:
                                                                  self.__prefilter_ref_wvscl + self.stationary_line_core,
                                                                  self.constant_wavelengths)
             else:
-                # TODO: Remove this warning and possibly all prefilter code
-                warnings.warn("prefilter_response will not be applied to spectra")
+                return  # None of the prefilter attributes are set, so no prefilter to apply.
         else:  # Make sure it is a numpy array so that division works as expected when doing array operations
             self.prefilter_response = np.asarray(self.prefilter_response, dtype=np.float64)
+
+        # TODO: Remove this warning and possibly all prefilter code
+        warnings.warn("Spectra should be fully processed before loading into MCALF. "
+                      "Prefilter response correction code may be removed in a later "
+                      "release.", PendingDeprecationWarning)
 
         # If a prefilter response is given it must be a compatible length
         if self.prefilter_response is not None:

--- a/src/mcalf/models/ibis.py
+++ b/src/mcalf/models/ibis.py
@@ -189,7 +189,7 @@ class IBIS8542Model(ModelBase):
             else:
                 return np.asarray(sigma, dtype=np.float64)
 
-    def _fit(self, spectrum, profile=None, sigma=None, classification=None, spectrum_index=None):
+    def _fit(self, spectrum, classification=None, spectrum_index=None, profile=None, sigma=None):
         """Fit a single spectrum for the given profile or classification
 
         Warning: Using this method directly will skip the corrections that are applied to spectra by the `get_spectra`
@@ -197,16 +197,16 @@ class IBIS8542Model(ModelBase):
 
         Parameters
         ----------
-        spectrum : ndarray, ndim=1, length=n_constant_wavelengths
+        spectrum : numpy.ndarray, ndim=1, length=n_constant_wavelengths
             The spectrum to be fitted.
-        profile : str, optional, default = None
-            The profile to fit. (Will infer profile from classification if omitted.)
-        sigma : ndarray, ndim=1, length=n_constant_wavelengths
-            The sigma array with weights for each spectral wavelength.
         classification : int, optional, default = None
             Classification to determine the fitted profile to use (if profile not explicitly given).
         spectrum_index : array_like or list or tuple, length=3, optional, default = None
             The [time, row, column] index of the `spectrum` provided. Only used for error reporting.
+        profile : str, optional, default = None
+            The profile to fit. (Will infer profile from classification if omitted.)
+        sigma : int or array_like, optional, default = None
+            Explicit sigma index or profile. See `_get_sigma` for details.
 
         Returns
         -------

--- a/src/mcalf/models/ibis.py
+++ b/src/mcalf/models/ibis.py
@@ -16,7 +16,7 @@ __all__ = ['IBIS8542Model']
 
 
 class IBIS8542Model(ModelBase):
-    """Class for working with IBIS 8542 Å calcium II spectral imaging observations
+    """Class for working with IBIS 8542 Å calcium II spectral imaging observations.
     
     Parameters
     ----------
@@ -25,9 +25,9 @@ class IBIS8542Model(ModelBase):
     Attributes
     ----------
     ${ATTRIBUTES}
-    quiescent_wavelength : int, default = 1
+    quiescent_wavelength : int, default=1
         The index within the fitted parameters of the absorption Voigt line core wavelength.
-    active_wavelength : int, default = 5
+    active_wavelength : int, default=5
         The index within the fitted parameters of the emission Voigt line core wavelength.
     ${ATTRIBUTES_EXTRA}
     """
@@ -110,7 +110,7 @@ class IBIS8542Model(ModelBase):
         self._validate_attributes()
 
     def _validate_attributes(self):
-        """Validate some of the object's attributes
+        """Validate some of the object's attributes.
 
         Raises
         ------
@@ -168,27 +168,27 @@ class IBIS8542Model(ModelBase):
                              "corresponding values in emission_min_bound")
 
     def _get_sigma(self, classification=None, sigma=None):
-        """Infer a sigma profile from the parameters provided
+        """Infer a sigma profile from the parameters provided.
 
         If no sigma is provided, use classification to take from the model object's sigma attribute.
         If sigma is provided and is an integer, take from the model object's sigma attribute at that index,
-        otherwise, return sigma as a NumPy array.
+        otherwise, return sigma as a :class:`numpy.ndarray`.
 
         Parameters
         ----------
-        classification : int, optional, default = None
+        classification : int, optional, default=None
             Classification sigma profile needed to fit.
-        sigma : int or array_like, optional, default = None
+        sigma : int or array_like, optional, default=None
             Explicit sigma index or profile.
 
         Returns
         -------
-        sigma : ndarray, length = n_constant_wavelengths
+        sigma : numpy.ndarray, length=n_constant_wavelengths
              The sigma profile.
 
         See Also
         --------
-        utils.generate_sigma : Generate a specified sigma profile
+        mcalf.utils.generate_sigma : Generate a specified sigma profile.
         """
         if sigma is None:
             # Decide how to weight the wavelengths
@@ -203,33 +203,33 @@ class IBIS8542Model(ModelBase):
                 return np.asarray(sigma, dtype=np.float64)
 
     def _fit(self, spectrum, classification=None, spectrum_index=None, profile=None, sigma=None):
-        """Fit a single spectrum for the given profile or classification
+        """Fit a single spectrum for the given profile or classification.
 
-        Warning: Using this method directly will skip the corrections that are applied to spectra by the `get_spectra`
-        method.
+        Warning: Using this method directly will skip the corrections that are applied to spectra by the
+        :meth:`~mcalf.models.ModelBase.get_spectra` method.
 
         Parameters
         ----------
         spectrum : numpy.ndarray, ndim=1, length=n_constant_wavelengths
             The spectrum to be fitted.
-        classification : int, optional, default = None
+        classification : int, optional, default=None
             Classification to determine the fitted profile to use (if profile not explicitly given).
-        spectrum_index : array_like or list or tuple, length=3, optional, default = None
+        spectrum_index : array_like or list or tuple, length=3, optional, default=None
             The [time, row, column] index of the `spectrum` provided. Only used for error reporting.
-        profile : str, optional, default = None
+        profile : str, optional, default=None
             The profile to fit. (Will infer profile from classification if omitted.)
-        sigma : int or array_like, optional, default = None
-            Explicit sigma index or profile. See `_get_sigma` for details.
+        sigma : int or array_like, optional, default=None
+            Explicit sigma index or profile. See :meth:`~mcalf.models.IBIS8542Model._get_sigma` for details.
 
         Returns
         -------
-        result : FitResult
-            Outcome of the fit returned in a FitResult object
+        result : mcalf.models.FitResult
+            Outcome of the fit returned in a :class:`~mcalf.models.FitResult` object.
 
         See Also
         --------
-        fit : The recommended method for fitting spectra
-        FitResult : The object that the fit method returns
+        fit : The recommended method for fitting spectra.
+        mcalf.models.FitResult : The object that the fit method returns.
         """
         if profile is None:  # If profile hasn't been specified, find it
 
@@ -281,49 +281,52 @@ class IBIS8542Model(ModelBase):
 
     def plot(self, fit=None, time=None, row=None, column=None, spectrum=None, classification=None, background=None,
              sigma=None, stationary_line_core=None, output=False, **kwargs):
-        """Plots the data and fitted parameters
+        """Plots the data and fitted parameters.
 
         Parameters
         ----------
-        fit : FitResult or list or array_like, optional, default = None
+        fit : mcalf.models.FitResult or list or array_like, optional, default=None
             The fitted parameters to plot with the data. Can extract the necessary plot metadata from the fit object.
             Otherwise, `fit` should be the parameters to be fitted to either a Voigt or double Voigt profile depending
             on the number of parameters fitted.
-        time : int or iterable, optional, default = None
-            The time index. The index can be either a single integer index or an iterable. E.g. a list, a NumPy
-            array, a Python range, etc. can be used.
-        row : int or iterable, optional, default = None
+        time : int or iterable, optional, default=None
+            The time index. The index can be either a single integer index or an iterable. E.g. a list,
+            :class:`numpy.ndarray`, a Python range, etc. can be used.
+        row : int or iterable, optional, default=None
             The row index. See comment for `time` parameter.
-        column : int or iterable, optional, default = None
+        column : int or iterable, optional, default=None
             The column index. See comment for `time` parameter.
-        spectrum : ndarray of length `original_wavelengths`, ndim=1, optional, default = None
+        spectrum : numpy.ndarray, length=`original_wavelengths`, ndim=1, optional, default=None
             The explicit spectrum to plot along with a fit (if specified).
-        classification : int, optional, default = None
-            Used to determine which sigma profile to use. See `_get_sigma` for more details.
-        background : float or array_like of length `constant_wavelengths`, optional, default = see note
+        classification : int, optional, default=None
+            Used to determine which sigma profile to use. See :meth:`~mcalf.models.IBIS8542Model._get_sigma`
+            for more details.
+        background : float or array_like, length=n_constant_wavelengths, optional, default= see note
             Background to added to the fitted profiles. If a `spectrum` is given, this will default to zero, otherwise
-            the value loaded by `load_background` will be used.
-        sigma : int or array_like, optional, default = None
-            Explicit sigma index or profile. See `_get_sigma` for details.
-        stationary_line_core : float, optional, default = `self.stationary_line_core`
+            the value loaded by :meth:`~mcalf.models.ModelBase.load_background` will be used.
+        sigma : int or array_like, optional, default=None
+            Explicit sigma index or profile. See :meth:`~mcalf.models.IBIS8542Model._get_sigma` for details.
+        stationary_line_core : float, optional, default=`stationary_line_core`
             The stationary line core wavelength to mark on the plot.
-        output : bool or str, optional, default = False
+        output : bool or str, optional, default=False
             Whether to save the plot to a file. If true, a file of format `plot_<time>_<row>_<column>.eps` will be
             created in the current directory. If a string, that will be used as the filename. (Can change filetype
             like this.) If false, no file will be created.
-        **kwargs
-            Parameters used by matplotlib and `separate` (see `plot_separate`) and `subtraction`
-            (see `plot_subtraction`).
-                - `figsize` passed to `matplotlib.pyplot.figure`
-                - `legend_position` passed to `matplotlib.pyplot.legend`
-                - `dpi` passed to `matplotlib.pyplot.figure` and `matplotlib.pyplot.savefig`
-                - `fontfamily` passed to `matplotlib.pyplot.rc('font', family=`fontfamily`)` if given
+        **kwargs : dict
+            Parameters used by :mod:`matplotlib.pyplot` and
+            `separate` (see :meth:`plot_separate`) and
+            `subtraction` (see :meth:`plot_subtraction`).
+
+            * `figsize` passed to :func:`matplotlib.pyplot.figure`.
+            * `legend_position` passed to :func:`matplotlib.pyplot.legend`.
+            * `dpi` passed to :func:`matplotlib.pyplot.figure` and :func:`matplotlib.pyplot.savefig`.
+            * `fontfamily` passed to `matplotlib.pyplot.rc('font', family=`fontfamily`)` if given.
 
         See Also
         --------
-        plot_separate : Plot the fit parameters separately
-        plot_subtraction : Plot the spectrum with the emission fit subtracted from it
-        FitResult.plot : Plotting method on the fit result
+        plot_separate : Plot the fit parameters separately.
+        plot_subtraction : Plot the spectrum with the emission fit subtracted from it.
+        mcalf.models.FitResult.plot : Plotting method on the fit result.
         """
         if fit.__class__ == FitResult:  # If fit is a `FitResult`
 
@@ -376,28 +379,28 @@ class IBIS8542Model(ModelBase):
                       stationary_line_core=stationary_line_core, output=output, **kwargs)
 
     def plot_separate(self, *args, **kwargs):
-        """Plot the fitted profiles separately
+        """Plot the fitted profiles separately.
 
-        If multiple profiles exist, fit them separately. See `plot` for more details.
+        If multiple profiles exist, fit them separately. See :meth:`plot` for more details.
 
         See Also
         --------
-        plot : General plotting method
-        plot_subtraction : Plot the spectrum with the emission fit subtracted from it
-        FitResult.plot : Plotting method on the fit result
+        plot : General plotting method.
+        plot_subtraction : Plot the spectrum with the emission fit subtracted from it.
+        mcalf.models.FitResult.plot : Plotting method on the fit result.
         """
         self.plot(*args, separate=True, **kwargs)
 
     def plot_subtraction(self, *args, **kwargs):
-        """Plot the spectrum with the emission fit subtracted from it
+        """Plot the spectrum with the emission fit subtracted from it.
 
-        If multiple profiles exist, subtract the fitted emission from the raw data. See `plot` for more details.
+        If multiple profiles exist, subtract the fitted emission from the raw data. See :meth:`plot` for more details.
 
         See Also
         --------
-        plot : General plotting method
-        plot_separate : Plot the fit parameters separately
-        FitResult.plot : Plotting method on the fit result
+        plot : General plotting method.
+        plot_separate : Plot the fit parameters separately.
+        mcalf.models.FitResult.plot : Plotting method on the fit result.
         """
         self.plot(*args, subtraction=True, **kwargs)
 
@@ -409,39 +412,40 @@ IBIS8542_ATTRIBUTES = copy.deepcopy(BASE_ATTRIBUTES)
 # Update documentation from base class (include new defaults)
 for d in [IBIS8542_PARAMETERS, IBIS8542_ATTRIBUTES]:
     d['stationary_line_core'] = """
-    stationary_line_core : float, optional, default = 8542.099145376844
+    stationary_line_core : float, optional, default=8542.099145376844
         Wavelength of the stationary line core."""
     d['sigma'] = """
-    sigma : list of array_like or bool, length=(2, n_wavelengths), optional, default = [type1, type2]
+    sigma : list of array_like or bool, length=(2, n_wavelengths), optional, default=[type1, type2]
         A list of different sigma that are used to weight particular wavelengths along the spectra when fitting. The
         fitting method will expect to be able to choose a sigma array from this list at a specific index. It's default
         value is `[generate_sigma(i, constant_wavelengths, stationary_line_core) for i in [1, 2]]`.
-        See `utils.generate_sigma()` for more information. If bool, True will generate the default sigma value
-        regardless of the value specified in `config`, and False will set `sigma` to be all ones, effectively disabling
-        it."""
+        See :func:`mcalf.utils.generate_sigma` for more information. 
+        If bool, True will generate the default sigma value regardless of the value specified in `config`,
+        and False will set `sigma` to be all ones, effectively disabling it."""
 IBIS8542_ATTRIBUTES['neural_network'] = """
-    neural_network : sklearn.neural_network.MLPClassifier, optional, default = see description
-        The MLPClassifier object (or similar) that will be used to classify the spectra. Defaults to a `GridSearchCV`
-        with `MLPClassifier(solver='lbfgs', hidden_layer_sizes=(40,), max_iter=1000)`
+    neural_network : sklearn.neural_network.MLPClassifier, optional, default= see description
+        The :class:`sklearn.neural_network.MLPClassifier` object (or similar) that will be used to
+        classify the spectra. Defaults to a :class:`sklearn.model_selection.GridSearchCV`
+        with :class:`~sklearn.neural_network.MLPClassifier(solver='lbfgs', hidden_layer_sizes=(40,), max_iter=1000)`
         for best `alpha` selected from `[1e-5, 2e-5, 3e-5, 4e-5, 5e-5, 6e-5, 7e-5, 8e-5, 9e-5]`."""
 
 # Add documentation for new parameters and attributes
 IBIS8542_DOCS = """        
-    absorption_guess : array_like, length=4, optional, default = [-1000, stationary_line_core, 0.2, 0.1]
+    absorption_guess : array_like, length=4, optional, default=[-1000, stationary_line_core, 0.2, 0.1]
         Initial guess to take when fitting the absorption Voigt profile.
-    emission_guess : array_like, length=4, optional, default = [1000, stationary_line_core, 0.2, 0.1]
+    emission_guess : array_like, length=4, optional, default=[1000, stationary_line_core, 0.2, 0.1]
         Initial guess to take when fitting the emission Voigt profile.
-    absorption_min_bound : array_like, length=4, optional, default = [-np.inf, stationary_line_core-0.15, 1e-6, 1e-6]
+    absorption_min_bound : array_like, length=4, optional, default=[-np.inf, stationary_line_core-0.15, 1e-6, 1e-6]
         Minimum bounds for all the absorption Voigt profile parameters in order of the function's arguments.
-    emission_min_bound : array_like, length=4, optional, default = [0, -np.inf, 1e-6, 1e-6]
+    emission_min_bound : array_like, length=4, optional, default=[0, -np.inf, 1e-6, 1e-6]
         Minimum bounds for all the emission Voigt profile parameters in order of the function's arguments.
-    absorption_max_bound : array_like, length=4, optional, default = [0, stationary_line_core+0.15, 1, 1]
+    absorption_max_bound : array_like, length=4, optional, default=[0, stationary_line_core+0.15, 1, 1]
         Maximum bounds for all the absorption Voigt profile parameters in order of the function's arguments.
-    emission_max_bound : array_like, length=4, optional, default = [np.inf, np.inf, 1, 1]
+    emission_max_bound : array_like, length=4, optional, default=[np.inf, np.inf, 1, 1]
         Maximum bounds for all the emission Voigt profile parameters in order of the function's arguments.
-    absorption_x_scale : array_like, length=4, optional, default = [1500, 0.2, 0.3, 0.5]
+    absorption_x_scale : array_like, length=4, optional, default=[1500, 0.2, 0.3, 0.5]
         Characteristic scale for all the absorption Voigt profile parameters in order of the function's arguments.
-    emission_x_scale : array_like, length=4, optional, default = [1500, 0.2, 0.3, 0.5]
+    emission_x_scale : array_like, length=4, optional, default=[1500, 0.2, 0.3, 0.5]
         Characteristic scale for all the emission Voigt profile parameters in order of the function's arguments."""
 
 # Form the docstring and do the replacements

--- a/src/mcalf/models/ibis.py
+++ b/src/mcalf/models/ibis.py
@@ -189,6 +189,37 @@ class IBIS8542Model(ModelBase):
         See Also
         --------
         mcalf.utils.generate_sigma : Generate a specified sigma profile.
+
+        Examples
+        --------
+
+        Create a basic model:
+
+        >>> import mcalf.models
+        >>> import numpy as np
+        >>> wavelengths = np.linspace(8541.3, 8542.7, 30)
+        >>> model = mcalf.models.IBIS8542Model(original_wavelengths=wavelengths)
+
+        Choose a sigma profile for the specified classification:
+
+        >>> model._get_sigma(classification=3)
+        array([1.        , 1.        , 1.        , 1.        , 1.        ,
+               0.99999606, 0.99909053, 0.95597984, 0.55338777, 0.05021681,
+               0.05021681, 0.05021681, 0.05021681, 0.4       , 0.4       ,
+               0.4       , 0.4       , 0.4       , 0.4       , 0.4       ,
+               0.05021681, 0.05021681, 0.05021681, 0.05021681, 0.57661719,
+               0.96043995, 0.99922519, 0.99999682, 1.        , 1.        ])
+
+        Get a specific sigma profile "index":
+
+        >>> (model._get_sigma(sigma=1) == model.sigma[1]).all()
+        True
+
+        Convert an array like object into a suitable datatype for a sigma profile:
+
+        >>> sigma = [1, 2, 3, 4, 5]
+        >>> model._get_sigma(sigma=sigma)
+        array([1., 2., 3., 4., 5.])
         """
         if sigma is None:
             # Decide how to weight the wavelengths
@@ -205,8 +236,9 @@ class IBIS8542Model(ModelBase):
     def _fit(self, spectrum, classification=None, spectrum_index=None, profile=None, sigma=None):
         """Fit a single spectrum for the given profile or classification.
 
-        Warning: Using this method directly will skip the corrections that are applied to spectra by the
-        :meth:`~mcalf.models.ModelBase.get_spectra` method.
+        .. warning::
+            Using this method directly will skip the corrections that are applied to spectra by the
+            :meth:`~mcalf.models.ModelBase.get_spectra` method. Use :meth:`.fit_spectrum` instead.
 
         Parameters
         ----------
@@ -228,7 +260,8 @@ class IBIS8542Model(ModelBase):
 
         See Also
         --------
-        fit : The recommended method for fitting spectra.
+        .fit_spectrum : The recommended method for fitting a single spectrum.
+        .fit : The recommended method for fitting multiple spectra.
         mcalf.models.FitResult : The object that the fit method returns.
         """
         if profile is None:  # If profile hasn't been specified, find it

--- a/src/mcalf/models/ibis.py
+++ b/src/mcalf/models/ibis.py
@@ -1,8 +1,6 @@
 import copy
 
 import numpy as np
-from pathos.multiprocessing import ProcessPool as Pool
-from sklearn.exceptions import NotFittedError
 from sklearn.model_selection import GridSearchCV
 from sklearn.neural_network import MLPClassifier
 
@@ -10,7 +8,7 @@ from mcalf.models.results import FitResult
 from mcalf.models.base import *
 from mcalf.profiles.voigt import voigt_nobg, double_voigt_nobg
 from mcalf.utils.spec import generate_sigma
-from mcalf.utils.misc import load_parameter, make_iter
+from mcalf.utils.misc import load_parameter
 from mcalf.visualisation.spec import plot_ibis8542
 
 
@@ -267,142 +265,6 @@ class IBIS8542Model(ModelBase):
                     'success': success, 'index': spectrum_index}
 
         return FitResult(fitted_parameters, fit_info)
-
-    def fit(self, time=None, row=None, column=None, spectrum=None, profile=None, sigma=None, classifications=None,
-            background=None, n_pools=None):
-        """Fits the model to specified spectra
-
-        Fits the model to an array of spectra using multiprocessing if requested.
-
-        Parameters
-        ----------
-        time : int or iterable, optional, default=None
-            The time index. The index can be either a single integer index or an iterable. E.g. a list, a NumPy
-            array, a Python range, etc. can be used.
-        row : int or iterable, optional, default=None
-            The row index. See comment for `time` parameter.
-        column : int or iterable, optional, default=None
-            The column index. See comment for `time` parameter.
-        spectrum : ndarray, ndim=1, optional, default=None
-            The explicit spectrum to fit the model to.
-        profile : str, optional, default = None
-            The profile to fit. (Will infer profile from `classifications` if omitted.)
-        sigma : int or array_like, optional, default = None
-            Explicit sigma index or profile. See `_get_sigma` for details.
-        classifications : int or array_like, optional, default = None
-            Classifications to determine the fitted profile to use (if profile not explicitly given). Will use
-            neural network to classify them if not. If a multidimensional array, must have the same shape as
-            [`time`, `row`, `column`]. Dimensions that would have length of 1 can be excluded.
-        background : float, optional, default = None
-            If provided, this value will be subtracted from the explicit spectrum provided in `spectrum`. Will
-            not be applied to spectra found from the indices, use the `load_background` method instead.
-        n_pools : int, optional, default = None
-            The number of processing pools to calculate the fitting over. This allocates the fitting of different
-            spectra to `n_pools` separate worker processes. When processing a large number of spectra this will make
-            the fitting process take less time overall. It also distributes such that each worker process has the
-            same ratio of classifications to process. This should balance out the workload between workers.
-            If few spectra are being fitted, performance may decrease due to the overhead associated with splitting
-            the evaluation over separate processes. If `n_pools` is not an integer greater than zero, it will fit
-            the spectrum with a for loop.
-
-        Returns
-        -------
-        result : list of FitResult, length=n_spectra
-            Outcome of the fits returned as a list of FitResult objects
-        """
-        # Specific fitting algorithm for IBIS Ca II 8542 Å
-
-        # Only include the background is using an explicit spectrum; remove for indices
-        include_background = False if spectrum is None else True
-        spectra = self.get_spectra(time=time, row=row, column=column, spectrum=spectrum, background=include_background)
-
-        # At least one valid spectrum must be given
-        n_valid = np.sum(~np.isnan(spectra[..., 0]))
-        if np.sum(~np.isnan(spectra[..., 0])) == 0:
-            raise ValueError("no valid spectra given")
-
-        if spectrum is not None and background is not None:  # remove explicit background of explicit spectrum
-            spectra -= background
-
-        if classifications is None:  # Classify if not already specified
-            classifications = self.classify_spectra(spectra=spectra, only_normalise=True)
-
-        if spectrum is None:  # No explicit spectrum given
-
-            # Create the array of indices that the spectra represent
-            time, row, column = make_iter(*self._get_time_row_column(time=time, row=row, column=column))
-            indices = np.transpose(np.array(np.meshgrid(time, row, column, indexing='ij')), axes=[1, 2, 3, 0])
-
-            # Ensure that length of arrays match
-            spectra_indices_shape_mismatch = spectra.shape[:-1] != indices.shape[:-1]
-            spectra_class_size_mismatch = np.size(spectra[..., 0]) != np.size(classifications)
-            spectra_class_shape_mismatch = False  # Only test this if appropriate
-            if isinstance(classifications, np.ndarray) and classifications.ndim != 1:
-                # If a multidimensional array of classifications are given, make sure it matches the indices layout
-                # Allow for dimensions of length 1 to be excluded
-                if np.squeeze(spectra[..., 0]).shape != np.squeeze(classifications).shape:
-                    spectra_class_shape_mismatch = True
-            if spectra_indices_shape_mismatch or spectra_class_size_mismatch or spectra_class_shape_mismatch:
-                raise ValueError("number classifications do not match number of spectra and associated indices")
-
-            # Make shape (n_spectra, n_features) so can process in a list
-            spectra = spectra.reshape(-1, spectra.shape[-1])
-            indices = indices.reshape(-1, indices.shape[-1])
-            classifications = np.asarray(classifications)  # Make sure ndarray methods are available
-            classifications = classifications.reshape(-1)
-
-            # Remove spectra that are invalid (this allows for masking of the loaded data to constrain a region to fit)
-            valid_spectra_i = np.where(~np.isnan(spectra[:, 0]))  # Where the first item of the spectrum is not NaN
-            spectra = spectra[valid_spectra_i]
-            indices = indices[valid_spectra_i]
-            classifications = classifications[valid_spectra_i]
-
-            if len(spectra) != len(indices) != len(classifications):  # Postprocessing sanity check
-                raise ValueError("number of spectra, number of recorded indices and number of classifications"
-                                 "are not the same (impossible error)")
-
-            # Multiprocessing not required
-            if n_pools is None or (isinstance(n_pools, (int, np.integer)) and n_pools <= 0):
-
-                print("Processing {} spectra".format(n_valid))
-                results = [self._fit(spectra[i], profile=profile, sigma=sigma, classification=classifications[i],
-                                     spectrum_index=indices[i]) for i in range(len(spectra))]
-
-            elif isinstance(n_pools, (int, np.integer)) and n_pools >= 1:  # Use multiprocessing
-
-                # Define single argument function that can be evaluated in the pools
-                def func(data, profile=profile, sigma=sigma):
-                    spectrum, index, classification = data  # Extract data and pass to `_fit` method
-                    return self._fit(spectrum, profile=profile, sigma=sigma, classification=classification,
-                                     spectrum_index=list(index))
-
-                # Sort the arrays in descending classification order
-                s = np.argsort(classifications)[::-1]  # Classifications indices sorted in descending order
-                spectra = spectra[s]
-                indices = indices[s]
-                classifications = classifications[s]
-
-                # Distribute the sorted spectra to each of `n_pools` in turn to ensure even workload
-                data = []
-                for pool in range(n_pools):
-                    data += [[spectra[i], indices[i], classifications[i]] for i in range(pool, len(spectra), n_pools)]
-
-                print("Processing {} spectra over {} pools".format(n_valid, n_pools))
-
-                with Pool(n_pools) as p:  # Send the job to the `n_pools` pools
-                    results = p.map(func, data)  # Map each element of `data` to the first argument of `func`
-                    p.close()  # Finished, so no more jobs to come
-                    p.join()  # Clean up the closed pools
-                    p.clear()  # Remove the server so it can be created again
-
-            else:
-                raise TypeError("n_pools must be an integer, got %s" % type(n_pools))
-
-        else:  # Explicit spectrum must be 1D so no loop needed
-            results = self._fit(spectra, profile=profile, sigma=sigma, classification=classifications,
-                                spectrum_index=None)
-
-        return results
 
     def plot(self, fit=None, time=None, row=None, column=None, spectrum=None, classification=None, background=None,
              sigma=None, stationary_line_core=None, output=False, **kwargs):

--- a/src/mcalf/models/ibis.py
+++ b/src/mcalf/models/ibis.py
@@ -17,6 +17,19 @@ __all__ = ['IBIS8542Model']
 
 class IBIS8542Model(ModelBase):
     """Class for working with IBIS 8542 Å calcium II spectral imaging observations
+    
+    Parameters
+    ----------
+    ${PARAMETERS}
+
+    Attributes
+    ----------
+    ${ATTRIBUTES}
+    quiescent_wavelength : int, default = 1
+        The index within the fitted parameters of the absorption Voigt line core wavelength.
+    active_wavelength : int, default = 5
+        The index within the fitted parameters of the emission Voigt line core wavelength.
+    ${ATTRIBUTES_EXTRA}
     """
     def __init__(self, **kwargs):
 
@@ -389,9 +402,11 @@ class IBIS8542Model(ModelBase):
         self.plot(*args, subtraction=True, **kwargs)
 
 
+# Copy documentation from base class
 IBIS8542_PARAMETERS = copy.deepcopy(BASE_PARAMETERS)
 IBIS8542_ATTRIBUTES = copy.deepcopy(BASE_ATTRIBUTES)
 
+# Update documentation from base class (include new defaults)
 for d in [IBIS8542_PARAMETERS, IBIS8542_ATTRIBUTES]:
     d['stationary_line_core'] = """
     stationary_line_core : float, optional, default = 8542.099145376844
@@ -404,13 +419,13 @@ for d in [IBIS8542_PARAMETERS, IBIS8542_ATTRIBUTES]:
         See `utils.generate_sigma()` for more information. If bool, True will generate the default sigma value
         regardless of the value specified in `config`, and False will set `sigma` to be all ones, effectively disabling
         it."""
-
 IBIS8542_ATTRIBUTES['neural_network'] = """
     neural_network : sklearn.neural_network.MLPClassifier, optional, default = see description
         The MLPClassifier object (or similar) that will be used to classify the spectra. Defaults to a `GridSearchCV`
         with `MLPClassifier(solver='lbfgs', hidden_layer_sizes=(40,), max_iter=1000)`
         for best `alpha` selected from `[1e-5, 2e-5, 3e-5, 4e-5, 5e-5, 6e-5, 7e-5, 8e-5, 9e-5]`."""
 
+# Add documentation for new parameters and attributes
 IBIS8542_DOCS = """        
     absorption_guess : array_like, length=4, optional, default = [-1000, stationary_line_core, 0.2, 0.1]
         Initial guess to take when fitting the absorption Voigt profile.
@@ -429,16 +444,18 @@ IBIS8542_DOCS = """
     emission_x_scale : array_like, length=4, optional, default = [1500, 0.2, 0.3, 0.5]
         Characteristic scale for all the emission Voigt profile parameters in order of the function's arguments."""
 
+# Form the docstring and do the replacements
 IBIS8542_PARAMETERS_STR = ''.join(IBIS8542_PARAMETERS[i] for i in IBIS8542_PARAMETERS)
 IBIS8542_ATTRIBUTES_STR = ''.join(IBIS8542_ATTRIBUTES[i] for i in IBIS8542_ATTRIBUTES)
-
-IBIS8542Model.__doc__ += """
-    Parameters
-    ----------""" + IBIS8542_DOCS + IBIS8542_PARAMETERS_STR + """
-
-    Attributes
-    ----------""" + IBIS8542_DOCS + """
-    quiescent_wavelength : int, default = 1
-        The index within the fitted parameters of the absorption Voigt line core wavelength.
-    active_wavelength : int, default = 5
-        The index within the fitted parameters of the emission Voigt line core wavelength.""" + IBIS8542_ATTRIBUTES_STR
+IBIS8542Model.__doc__ = IBIS8542Model.__doc__.replace(
+    '${PARAMETERS}',
+    (IBIS8542_DOCS + IBIS8542_PARAMETERS_STR).lstrip()
+)
+IBIS8542Model.__doc__ = IBIS8542Model.__doc__.replace(
+    '${ATTRIBUTES}',
+    IBIS8542_DOCS.lstrip()
+)
+IBIS8542Model.__doc__ = IBIS8542Model.__doc__.replace(
+    '${ATTRIBUTES_EXTRA}',
+    IBIS8542_ATTRIBUTES_STR.lstrip()
+)

--- a/src/mcalf/tests/models/test_ibis.py
+++ b/src/mcalf/tests/models/test_ibis.py
@@ -91,11 +91,11 @@ def test_ibis8542model_configfile():
     IBIS8542Model(config="ibis8542model_config.yml", sigma=False)
 
     # Test with defined prefilter
-    IBIS8542Model(config="ibis8542model_config_prefilter.yml")
+    with pytest.deprecated_call():
+        IBIS8542Model(config="ibis8542model_config_prefilter.yml")
 
     # Test with no prefilter
-    with pytest.warns(UserWarning, match='prefilter_response'):
-        IBIS8542Model(config="ibis8542model_config_noprefilter.yml")
+    IBIS8542Model(config="ibis8542model_config_noprefilter.yml")
 
     # TODO Check that the parameters were imported correctly
 

--- a/src/mcalf/tests/models/test_results.py
+++ b/src/mcalf/tests/models/test_results.py
@@ -26,7 +26,7 @@ def test_fitresult_passthrough():
 
 
 def test_fitresult_velocity():
-    m = DummyModel()
+    m = DummyModel(original_wavelengths=[1000.4, 1000.6])
     m.stationary_line_core = 1000.5
     m.quiescent_wavelength = 2
     m.active_wavelength = 3
@@ -129,7 +129,7 @@ def test_fitresults_append():
 
 
 def test_fitresults_velocities():
-    m = DummyModel()
+    m = DummyModel(original_wavelengths=[1000.4, 1000.6])
     m.stationary_line_core = 1000.5
     m.quiescent_wavelength = 0
     m.active_wavelength = 1

--- a/src/mcalf/tests/utils/test_spec.py
+++ b/src/mcalf/tests/utils/test_spec.py
@@ -37,7 +37,7 @@ def test_normalise_spectrum():
 
 
 def test_normalise_spectrum_model():
-    m = DummyModel()
+    m = DummyModel(original_wavelengths=[0.0, 0.1])
     m.original_wavelengths = np.linspace(-20, 20, 15)
     m.constant_wavelengths = m.original_wavelengths * 0.9
     np.random.seed(0)  # Produce identical results

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{36,37,38}{,-oldestdeps}
-    build_docs
+    build_docs{,-dev}
 
 [testenv]
 changedir = .tmp/{envname}
@@ -27,5 +27,13 @@ commands =
 changedir = docs
 description = invoke sphinx-build to build the HTML docs
 extras = docs
+commands =
+    sphinx-build -j auto -b html . _build/html
+
+[testenv:build_docs-dev]
+changedir = docs
+description = invoke sphinx-build to build the HTML docs (using patched sphinx-automodapi)
+deps =
+    -rdocs/requirements.txt
 commands =
     sphinx-build -j auto -b html . _build/html


### PR DESCRIPTION
## Description
Moving attributes and methods from the child models (IBIS8542Model) to the base model class (ModelBase). This should make it easier to create new models based on ModelBase. I also plan to create intermediate models which implement a standard fitting routine for fitting a particular number of spectral components (one or two components initially). The top level classes would then supply default values to these lower level classes, such as to control the amplitude of the fitted components without having to reimplement the fitting algorithm and other methods.

## First commit: Refactor init attributes and parameters
Most parameters have now been moved to the base class. Steps taken during initialisation have been made clearer. Docstring for model classes are now formed dynamically. Due to moving original_wavelengths parameter/attribute from child to base class, base class must now be initialised with at least original_wavelenghts. A few tests did not give this parameter so were failing. Only changes made to test suite to allow this commit to pass was providing original_wavelengths to this test. Everything else works as before.