### PR TITLE
Remove documentation for special methods

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,11 +50,7 @@ extensions = [
 ]
 numpydoc_show_class_members = False
 nbsphinx_execute = 'never'
-all_methods = [
-    'mcalf.models.ModelBase',
-]
-automodsumm_private_methods_of = all_methods
-automodsumm_special_methods_of = all_methods
+automodsumm_private_methods_of = ['mcalf.models.ModelBase']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
As inherited classes are now being documented, need to disable documentation of special methods to remove `object` special methods from ModelBase documentation.