### PR TITLE
Tidy mcalf.profiles

### DIFF
--- a/src/mcalf/profiles/gaussian.py
+++ b/src/mcalf/profiles/gaussian.py
@@ -1,8 +1,7 @@
 import numpy as np
-from scipy.special import erf
 
 
-__all__ = ['single_gaussian', 'skew_normal', 'skew_normal_with_gaussian']
+__all__ = ['single_gaussian']
 
 
 def single_gaussian(x, a, b, c, d):
@@ -28,23 +27,3 @@ def single_gaussian(x, a, b, c, d):
     """
     g = a * np.exp(- (x-b)**2.0 / (2.0 * c**2.0))
     return g + d
-
-
-def _skew_normal_with_gaussian(x, a_a=0, alpha=1, xi=0, omega=1, a_e=0, b=0, c=1, d=0):
-    x1 = (x - xi) / omega
-    pdf = np.exp(- x1 ** 2.0 / 2.0) / np.sqrt(2.0 * np.pi)
-    cdf = 0.5 * (1.0 + erf(alpha * x1 / np.sqrt(2.0)))
-    skewed_normal = 2.0 * pdf * cdf / omega
-
-    absorption = a_a * skewed_normal
-    emission = a_e * np.exp(- (x - b) ** 2.0 / (2.0 * c ** 2.0))
-
-    return absorption + emission + d
-
-
-def skew_normal(x, a_a, alpha, xi, omega, d):
-    return _skew_normal_with_gaussian(x, a_a=a_a, alpha=alpha, xi=xi, omega=omega, d=d)
-
-
-def skew_normal_with_gaussian(x, a_a, alpha, xi, omega, a_e, b, c, d):  # This can be optimised later
-    return _skew_normal_with_gaussian(x, a_a=a_a, alpha=alpha, xi=xi, omega=omega, a_e=a_e, b=b, c=c, d=d)

--- a/src/mcalf/profiles/voigt.py
+++ b/src/mcalf/profiles/voigt.py
@@ -43,41 +43,9 @@ def voigt_approx_nobg(x, a, b, s, g):
 
     Parameters
     ----------
-    x : numpy.ndarray
-        Wavelengths to evaluate Voigt function at.
-    a : float
-        Amplitude of the Lorentzian.
-    b : float
-        Central line core.
-    s : float
-        Sigma (for Gaussian).
-    g : float
-        Gamma (for Lorentzian).
+    ${SINGLE_VOIGT}
 
-    Returns
-    -------
-    result : numpy.ndarray, shape=`x.shape`
-        The value of the Voigt function here.
-
-    See Also
-    --------
-    voigt_approx : Approximated Voigt function with background added.
-    double_voigt_approx_nobg : Two approximated Voigt functions added together.
-    double_voigt_approx : Two approximated Voigt functions and a background added together.
-    voigt_nobg : Base Voigt function with no background.
-    voigt : Voigt function with background added.
-    double_voigt_nobg : Two Voigt functions added together.
-    double_voigt : Two Voigt function and a background added together.
-
-    Notes
-    -----
-    This algorithm is taken from A. B. McLean et al. [1]_.
-
-    References
-    ----------
-    .. [1] A. B. McLean, C. E. J. Mitchell and D. M. Swanston, "Implementation of an efficient analytical
-      approximation to the Voigt function for photoemission lineshape analysis," Journal of Electron Spectroscopy and
-      Related Phenomena, vol. 69, pp. 125-132, 1994. https://doi.org/10.1016/0368-2048(94)02189-7
+    ${EXTRA_APPROX}
     """
     fwhm_g = 2 * s * np.sqrt(2 * np.log(2))
     fwhm_l = 2 * g
@@ -94,33 +62,10 @@ def voigt_approx(x, a, b, s, g, d):
 
     Parameters
     ----------
-    x : numpy.ndarray
-        Wavelengths to evaluate Voigt function at.
-    a : float
-        Amplitude of the Lorentzian.
-    b : float
-        Central line core.
-    s : float
-        Sigma (for Gaussian).
-    g : float
-        Gamma (for Lorentzian).
-    d : float
-        Background.
+    ${SINGLE_VOIGT}
+    ${BACKGROUND}
 
-    Returns
-    -------
-    result : numpy.ndarray, shape=`x.shape`
-        The value of the Voigt function here.
-
-    See Also
-    --------
-    voigt_approx_nobg : Base approximated Voigt function with no background.
-    double_voigt_approx_nobg : Two approximated Voigt functions added together.
-    double_voigt_approx : Two approximated Voigt functions and a background added together.
-    voigt_nobg : Base Voigt function with no background.
-    voigt : Voigt function with background added.
-    double_voigt_nobg : Two Voigt functions added together.
-    double_voigt : Two Voigt function and a background added together.
+    ${EXTRA_APPROX}
     """
     return voigt_approx_nobg(x, a, b, s, g) + d
 
@@ -130,39 +75,9 @@ def double_voigt_approx_nobg(x, a1, b1, s1, g1, a2, b2, s2, g2):
 
     Parameters
     ----------
-    x : numpy.ndarray
-        Wavelengths to evaluate Voigt function at.
-    a1 : float
-        Amplitude of the Lorentzian of 1st Voigt function.
-    b1 : float
-        Central line core of 1st Voigt function.
-    s1 : float
-        Sigma (for Gaussian) of 1st Voigt function.
-    g1 : float
-        Gamma (for Lorentzian) of 1st Voigt function.
-    a2 : float
-        Amplitude of 2st Voigt function.
-    b2 : float
-        Central line core of 2st Voigt function.
-    s2 : float
-        Sigma (for Gaussian) of 2st Voigt function.
-    g2 : float
-        Gamma (for Lorentzian) of 2st Voigt function.
+    ${DOUBLE_VOIGT}
 
-    Returns
-    -------
-    result : numpy.ndarray, shape=`x.shape`
-        The value of the Voigt function here.
-
-    See Also
-    --------
-    voigt_approx_nobg : Base approximated Voigt function with no background.
-    voigt_approx : Approximated Voigt function with background added.
-    double_voigt_approx : Two approximated Voigt functions and a background added together.
-    voigt_nobg : Base Voigt function with no background.
-    voigt : Voigt function with background added.
-    double_voigt_nobg : Two Voigt functions added together.
-    double_voigt : Two Voigt function and a background added together.
+    ${EXTRA_APPROX}
     """
     return voigt_approx_nobg(x, a1, b1, s1, g1) + voigt_approx_nobg(x, a2, b2, s2, g2)
 
@@ -172,41 +87,10 @@ def double_voigt_approx(x, a1, b1, s1, g1, a2, b2, s2, g2, d):
 
     Parameters
     ----------
-    x : numpy.ndarray
-        Wavelengths to evaluate Voigt function at.
-    a1 : float
-        Amplitude of the Lorentzian of 1st Voigt function.
-    b1 : float
-        Central line core of 1st Voigt function.
-    s1 : float
-        Sigma (for Gaussian) of 1st Voigt function.
-    g1 : float
-        Gamma (for Lorentzian) of 1st Voigt function.
-    a2 : float
-        Amplitude of 2st Voigt function.
-    b2 : float
-        Central line core of 2st Voigt function.
-    s2 : float
-        Sigma (for Gaussian) of 2st Voigt function.
-    g2 : float
-        Gamma (for Lorentzian) of 2st Voigt function.
-    d : float
-        Background.
+    ${DOUBLE_VOIGT}
+    ${BACKGROUND}
 
-    Returns
-    -------
-    result : numpy.ndarray, shape=`x.shape`
-        The value of the Voigt function here.
-
-    See Also
-    --------
-    voigt_approx_nobg : Base approximated Voigt function with no background.
-    voigt_approx : Approximated Voigt function with background added.
-    double_voigt_approx_nobg : Two approximated Voigt functions added together.
-    voigt_nobg : Base Voigt function with no background.
-    voigt : Voigt function with background added.
-    double_voigt_nobg : Two Voigt functions added together.
-    double_voigt : Two Voigt function and a background added together.
+    ${EXTRA_APPROX}
     """
     return voigt_approx_nobg(x, a1, b1, s1, g1) + voigt_approx_nobg(x, a2, b2, s2, g2) + d
 
@@ -218,36 +102,10 @@ def voigt_nobg(x, a, b, s, g, clib=True):
 
     Parameters
     ----------
-    x : numpy.ndarray
-        Wavelengths to evaluate Voigt function at.
-    a : float
-        Amplitude.
-    b : float
-        Central line core.
-    s : float
-        Sigma (for Gaussian).
-    g : float
-        Gamma (for Lorentzian).
-    clib : bool, optional, default=True
-        Whether to use the complied C library or a slower Python version. If using the C library, the accuracy
-        of the integration is reduced to give the code a significant speed boost. Python version can be used when
-        speed is not a priority. Python version will remove deviations that are sometimes present around the wings
-        due to the reduced accuracy.
+    ${SINGLE_VOIGT}
+    ${CLIB}
 
-    Returns
-    -------
-    result : numpy.ndarray, shape=`x.shape`
-        The value of the Voigt function here.
-
-    See Also
-    --------
-    voigt : Voigt function with background added.
-    double_voigt_nobg : Two Voigt functions added together.
-    double_voigt : Two Voigt function and a background added together.
-
-    Notes
-    -----
-    More information on the Voigt function can be found here: https://en.wikipedia.org/wiki/Voigt_profile
+    ${EXTRA_STD}
     """
     warnings.filterwarnings("ignore", category=IntegrationWarning)
     u = x - b
@@ -264,38 +122,11 @@ def voigt(x, a, b, s, g, d, clib=True):
 
     Parameters
     ----------
-    x : numpy.ndarray
-        Wavelengths to evaluate Voigt function at.
-    a : float
-        Amplitude.
-    b : float
-        Central line core.
-    s : float
-        Sigma (for Gaussian).
-    g : float
-        Gamma (for Lorentzian).
-    d : float
-        Background.
-    clib : bool, optional, default=True
-        Whether to use the complied C library or a slower Python version. If using the C library, the accuracy
-        of the integration is reduced to give the code a significant speed boost. Python version can be used when
-        speed is not a priority. Python version will remove deviations that are sometimes present around the wings
-        due to the reduced accuracy.
+    ${SINGLE_VOIGT}
+    ${BACKGROUND}
+    ${CLIB}
 
-    Returns
-    -------
-    result : numpy.ndarray, shape=`x.shape`
-        The value of the Voigt function here.
-
-    See Also
-    --------
-    voigt_nobg : Base Voigt function with no background.
-    double_voigt_nobg : Two Voigt functions added together.
-    double_voigt : Two Voigt function and a background added together.
-
-    Notes
-    -----
-    More information on the Voigt function can be found here: https://en.wikipedia.org/wiki/Voigt_profile
+    ${EXTRA_STD}
     """
     return voigt_nobg(x, a, b, s, g, clib) + d
 
@@ -305,44 +136,10 @@ def double_voigt_nobg(x, a1, b1, s1, g1, a2, b2, s2, g2, clib=True):
 
     Parameters
     ----------
-    x : numpy.ndarray
-        Wavelengths to evaluate Voigt function at.
-    a1 : float
-        Amplitude of 1st Voigt function.
-    b1 : float
-        Central line core of 1st Voigt function.
-    s1 : float
-        Sigma (for Gaussian) of 1st Voigt function.
-    g1 : float
-        Gamma (for Lorentzian) of 1st Voigt function.
-    a2 : float
-        Amplitude of 2st Voigt function.
-    b2 : float
-        Central line core of 2st Voigt function.
-    s2 : float
-        Sigma (for Gaussian) of 2st Voigt function.
-    g2 : float
-        Gamma (for Lorentzian) of 2st Voigt function.
-    clib : bool, optional, default=True
-        Whether to use the complied C library or a slower Python version. If using the C library, the accuracy
-        of the integration is reduced to give the code a significant speed boost. Python version can be used when
-        speed is not a priority. Python version will remove deviations that are sometimes present around the wings
-        due to the reduced accuracy.
+    ${DOUBLE_VOIGT}
+    ${CLIB}
 
-    Returns
-    -------
-    result : numpy.ndarray, shape=`x.shape`
-        The value of the Voigt function here.
-
-    See Also
-    --------
-    voigt_nobg : Base Voigt function with no background.
-    voigt : Voigt function with background added.
-    double_voigt : Two Voigt function and a background added together.
-
-    Notes
-    -----
-    More information on the Voigt function can be found here: https://en.wikipedia.org/wiki/Voigt_profile
+    ${EXTRA_STD}
     """
     return voigt_nobg(x, a1, b1, s1, g1, clib) + voigt_nobg(x, a2, b2, s2, g2, clib)
 
@@ -352,8 +149,29 @@ def double_voigt(x, a1, b1, s1, g1, a2, b2, s2, g2, d, clib=True):
 
     Parameters
     ----------
+    ${DOUBLE_VOIGT}
+    ${BACKGROUND}
+    ${CLIB}
+
+    ${EXTRA_STD}
+    """
+    return double_voigt_nobg(x, a1, b1, s1, g1, a2, b2, s2, g2, clib) + d
+
+
+# Define "Parameters" options
+__input_x = """
     x : numpy.ndarray
-        Wavelengths to evaluate Voigt function at.
+        Wavelengths to evaluate Voigt function at."""
+__single_voigt = __input_x + """
+    a : float
+        Amplitude of the Lorentzian.
+    b : float
+        Central line core.
+    s : float
+        Sigma (for Gaussian).
+    g : float
+        Gamma (for Lorentzian)."""
+__double_voigt = __input_x + """
     a1 : float
         Amplitude of 1st Voigt function.
     b1 : float
@@ -363,34 +181,104 @@ def double_voigt(x, a1, b1, s1, g1, a2, b2, s2, g2, d, clib=True):
     g1 : float
         Gamma (for Lorentzian) of 1st Voigt function.
     a2 : float
-        Amplitude of 2st Voigt function.
+        Amplitude of 2nd Voigt function.
     b2 : float
-        Central line core of 2st Voigt function.
+        Central line core of 2nd Voigt function.
     s2 : float
-        Sigma (for Gaussian) of 2st Voigt function.
+        Sigma (for Gaussian) of 2nd Voigt function.
     g2 : float
-        Gamma (for Lorentzian) of 2st Voigt function.
+        Gamma (for Lorentzian) of 2nd Voigt function."""
+__background = """
     d : float
-        Background.
+        Background."""
+__clib = """
     clib : bool, optional, default=True
         Whether to use the complied C library or a slower Python version. If using the C library, the accuracy
         of the integration is reduced to give the code a significant speed boost. Python version can be used when
         speed is not a priority. Python version will remove deviations that are sometimes present around the wings
-        due to the reduced accuracy.
+        due to the reduced accuracy."""
 
+# Define "Returns"
+__returns = """
     Returns
     -------
     result : numpy.ndarray, shape=`x.shape`
         The value of the Voigt function here.
 
-    See Also
-    --------
-    voigt_nobg : Base Voigt function with no background.
-    voigt : Voigt function with background added.
-    double_voigt_nobg : Two Voigt functions added together.
+    """
 
+# Define "Notes" (and "References") section
+__notes_approx = """
     Notes
     -----
-    More information on the Voigt function can be found here: https://en.wikipedia.org/wiki/Voigt_profile
-    """
-    return double_voigt_nobg(x, a1, b1, s1, g1, a2, b2, s2, g2, clib) + d
+    This algorithm is taken from A. B. McLean et al. [1]_.
+
+    References
+    ----------
+    .. [1] A. B. McLean, C. E. J. Mitchell and D. M. Swanston, "Implementation of an efficient analytical
+      approximation to the Voigt function for photoemission lineshape analysis," Journal of Electron Spectroscopy and
+      Related Phenomena, vol. 69, pp. 125-132, 1994. https://doi.org/10.1016/0368-2048(94)02189-7"""
+__notes_std = """
+    Notes
+    -----
+    More information on the Voigt function can be found here: https://en.wikipedia.org/wiki/Voigt_profile"""
+
+
+# Define special "See Also" options
+__see_also_approx = [
+    '    voigt_approx_nobg : Base approximated Voigt function with no background.',
+    '    voigt_approx : Approximated Voigt function with background added.',
+    '    double_voigt_approx_nobg : Two approximated Voigt functions added together.',
+    '    double_voigt_approx : Two approximated Voigt functions and a background added together.',
+]
+__see_also_std = [
+    '    voigt_nobg : Base Voigt function with no background.',
+    '    voigt : Voigt function with background added.',
+    '    double_voigt_nobg : Two Voigt functions added together.',
+    '    double_voigt : Two Voigt function and a background added together.',
+]
+# Extract the function name for easy exclusion of item
+__see_also_approx = [(i.split(':')[0].strip(), i) for i in __see_also_approx]
+__see_also_std = [(i.split(':')[0].strip(), i) for i in __see_also_std]
+__see_also = __see_also_approx + __see_also_std
+
+
+def __rm_self(func, items):
+    """Return the "See Also" section with the current function removed."""
+    ret = [i[1] for i in items if i[0] != func]
+    return 'See Also\n    --------\n    ' + '\n'.join(ret).lstrip() + '\n'
+
+
+def __extra_approx(func):
+    """Merge common approx functions sections."""
+    return __returns + __rm_self(func.__name__, __see_also) + __notes_approx
+
+
+def __extra_std(func):
+    """Merge common standard functions sections."""
+    return __returns + __rm_self(func.__name__, __see_also_std) + __notes_std
+
+
+for f in [voigt_approx_nobg, voigt_approx, double_voigt_approx_nobg, double_voigt_approx,
+          voigt_nobg, voigt, double_voigt_nobg, double_voigt]:
+    f.__doc__ = f.__doc__.replace('${SINGLE_VOIGT}', __single_voigt.lstrip())
+    f.__doc__ = f.__doc__.replace('${DOUBLE_VOIGT}', __double_voigt.lstrip())
+    f.__doc__ = f.__doc__.replace('${BACKGROUND}', __background.lstrip())
+    f.__doc__ = f.__doc__.replace('${CLIB}', __clib.lstrip())
+    f.__doc__ = f.__doc__.replace('${EXTRA_APPROX}', __extra_approx(f).lstrip())
+    f.__doc__ = f.__doc__.replace('${EXTRA_STD}', __extra_std(f).lstrip())
+
+del __input_x
+del __single_voigt
+del __double_voigt
+del __background
+del __clib
+del __returns
+del __notes_approx
+del __notes_std
+del __see_also_approx
+del __see_also_std
+del __see_also
+del __rm_self
+del __extra_approx
+del __extra_std


### PR DESCRIPTION
- Convert Voigt functions' docstrings into common sections/strings that are inserted into each function with replacement strings.
- Remove unused skew normal distribution functions. 