### PR TITLE
Upgrade Python version to 3.7-3.9

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,7 @@
+variables:
+  CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+  CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+
 resources:
   repositories:
   - repository: OpenAstronomy
@@ -20,12 +24,12 @@ stages:
     jobs:
     - template: run-tox-env.yml@OpenAstronomy
       parameters:
-        default_python: '3.8'
+        default_python: '3.9'
         coverage: codecov
         posargs: -n=4
 
         envs:
-        - linux: py38
+        - linux: py39
 
   - stage: StageTwoTests
     displayName: Detailed Tests
@@ -33,7 +37,7 @@ stages:
     jobs:
     - template: run-tox-env.yml@OpenAstronomy
       parameters:
-        default_python: '3.8'
+        default_python: '3.9'
         coverage: codecov
         posargs: -n=4
 
@@ -43,19 +47,19 @@ stages:
 
         envs:
 
-        - linux: py36
-          libraries: {}
         - linux: py37
           libraries: {}
-
-        - macos: py38
+        - linux: py38
           libraries: {}
 
-        - windows: py38
+        - macos: py39
+          libraries: {}
+
+        - windows: py39
           libraries: {}
 
         # Test that the oldest dependency versions with on the latest supported Python version
-        - linux: py38-oldestdeps
+        - linux: py39-oldestdeps
           libraries: {}
 
 #        - linux: build_docs
@@ -68,13 +72,13 @@ stages:
     jobs:
     - template: run-tox-env.yml@OpenAstronomy
       parameters:
-        default_python: '3.8'
+        default_python: '3.9'
         coverage: codecov
         posargs: -n=4
         envs:
-        - linux: py38-figure
-        - macos: py38-figure
-        - windows: py38-figure
+        - linux: py39-figure
+        - macos: py39-figure
+        - windows: py39-figure
 
   # RELEASING A VERSION: Run more detailed tests if releasing a version (or if triggered manually)
   - ${{ if or(startsWith(variables['Build.SourceBranch'], 'refs/tags/v'), eq(variables['Build.Reason'], 'Manual')) }}:
@@ -84,35 +88,35 @@ stages:
       jobs:
       - template: run-tox-env.yml@OpenAstronomy
         parameters:
-          default_python: '3.8'
+          default_python: '3.9'
           coverage: codecov
           posargs: -n=4
 
           envs:
 
-#          - linux: py36
 #          - linux: py37
 #          - linux: py38
+#          - linux: py39
 
-          - macos: py36
           - macos: py37
-#          - macos: py38
+          - macos: py38
+#          - macos: py39
 
-          - windows: py36
           - windows: py37
-#          - windows: py38
+          - windows: py38
+#          - windows: py39
 
-          - linux: py36-oldestdeps
           - linux: py37-oldestdeps
-#          - linux: py38-oldestdeps
+          - linux: py38-oldestdeps
+#          - linux: py39-oldestdeps
 
-          - macos: py36-oldestdeps
           - macos: py37-oldestdeps
           - macos: py38-oldestdeps
+          - macos: py39-oldestdeps
 
-          - windows: py36-oldestdeps
           - windows: py37-oldestdeps
           - windows: py38-oldestdeps
+          - windows: py39-oldestdeps
 
   # Don't build sdist and wheels for PRs
   # Note: cannot run tests in this job as tests are outside package
@@ -131,6 +135,6 @@ stages:
           test_command: pytest --pyargs mcalf
           targets:
           - sdist
-          - wheels_cp3[6-8]-macosx_x86_64
-          - wheels_cp3[6-8]-manylinux*
-          - wheels_cp3[6-8]-win_amd64
+          - wheels_cp3[7-9]-macosx_x86_64
+          - wheels_cp3[7-9]-manylinux*
+          - wheels_cp3[7-9]-win_amd64

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,7 @@ stages:
           libraries: {}
 
         # Test that the oldest dependency versions with on the latest supported Python version
-        - linux: py39-oldestdeps
+        - linux: py37-oldestdeps
           libraries: {}
 
 #        - linux: build_docs
@@ -106,20 +106,11 @@ stages:
           - windows: py38
 #          - windows: py39
 
-          - linux: py37-oldestdeps
-          - linux: py38-oldestdeps
-#          - linux: py39-oldestdeps
-
+#          - linux: py37-oldestdeps
           - macos: py37-oldestdeps
-          - macos: py38-oldestdeps
-          - macos: py39-oldestdeps
-
           - windows: py37-oldestdeps
-          - windows: py38-oldestdeps
-          - windows: py39-oldestdeps
 
   # Don't build sdist and wheels for PRs
-  # Note: cannot run tests in this job as tests are outside package
   - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
     - stage: Release
       condition: or(succeeded(), eq(variables['Build.Reason'], 'Manual'))

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,24 +15,24 @@ classifiers =
   Operating System :: OS Independent
   Programming Language :: C
   Programming Language :: Python :: 3
-  Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
+  Programming Language :: Python :: 3.9
   Topic :: Scientific/Engineering :: Astronomy
   Topic :: Scientific/Engineering :: Physics
 project_urls =
     Documentation = https://mcalf.macbride.me/
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 package_dir =
     = src
 packages = find:
 include_package_data = True
 install_requires =
-  astropy>=3.2
+  astropy>=4.2
   matplotlib>=3.1
-  numpy>=1.17
+  numpy>=1.18
   pathos>=0.2.5
   pyyaml>=5.1
   scikit-learn>=0.22

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38}{,-oldestdeps,-figure}
+    py{37,38,39}{,-oldestdeps,-figure}
     build_docs{,-dev}
 
 [testenv]
@@ -12,9 +12,9 @@ deps =
     pytest-xdist
     pytest-logger
     # Set oldest versions of dependencies
-    oldestdeps: astropy==3.2.*
+    oldestdeps: astropy==4.2.*
     oldestdeps: matplotlib==3.1.*
-    oldestdeps: numpy==1.17.*
+    oldestdeps: numpy==1.18.*
     oldestdeps: pathos==0.2.5
     oldestdeps: pyyaml==5.1.*
     oldestdeps: scikit-learn==0.22.*


### PR DESCRIPTION
- Drops support for Python 3.6
- Adds support for Python 3.9
- Min. Numpy 1.17 -> 1.18
- Min. Astropy 3.2 -> 4.2
- Use ``manylinux2014``

## Todo
- [x] Change all py39-oldestdeps to py37-oldestdeps
- ~[ ] Investigate PyYAML import method (try block may not be needed)~