### PR TITLE
Support for changing the Voigt implementation

### DIFF
--- a/src/mcalf/models/base.py
+++ b/src/mcalf/models/base.py
@@ -687,7 +687,7 @@ class ModelBase:
 
         return spectra
 
-    def _fit(self, spectrum, classification=None, spectrum_index=None):
+    def _fit(self, spectrum, classification=None, spectrum_index=None, **kwargs):
         """Fit a single spectrum for the given profile or classification.
 
         .. warning::
@@ -945,7 +945,7 @@ class ModelBase:
         """
         return self.fit(spectrum=spectrum, **kwargs)
 
-    def _curve_fit(self, model, spectrum, guess, sigma, bounds, x_scale, time=None, row=None, column=None):
+    def _curve_fit(self, model, spectrum, guess, sigma, bounds, x_scale, time=None, row=None, column=None, **kwargs):
         """:func:`scipy.optimize.curve_fit` wrapper with error handling.
 
         Passes a certain set of parameters to the :func:`scipy.optimize.curve_fit` function and catches some typical
@@ -993,14 +993,14 @@ class ModelBase:
         try:  # TODO Investigate if there is a performance gain to setting `check_finite` to False
 
             fitted_parameters = curve_fit(model, self.constant_wavelengths, spectrum,
-                                          p0=guess, sigma=sigma, bounds=bounds, x_scale=x_scale)[0]
+                                          p0=guess, sigma=sigma, bounds=bounds, x_scale=x_scale, **kwargs)[0]
             success = True
 
-        except RuntimeError:
+        except RuntimeError as e:
 
             success = False
             location_text = " at ({}, {}, {})".format(time, row, column) if time is not None else ''
-            warnings.warn("RuntimeError{}".format(location_text))
+            warnings.warn(f"RuntimeError({e}){location_text}")
             fitted_parameters = np.full_like(guess, np.nan)
 
         except ValueError as e:

--- a/src/mcalf/models/ibis.py
+++ b/src/mcalf/models/ibis.py
@@ -235,7 +235,7 @@ class IBIS8542Model(ModelBase):
             else:
                 return np.asarray(sigma, dtype=np.float64)
 
-    def _fit(self, spectrum, classification=None, spectrum_index=None, profile=None, sigma=None):
+    def _fit(self, spectrum, classification=None, spectrum_index=None, profile=None, sigma=None, **kwargs):
         """Fit a single spectrum for the given profile or classification.
 
         .. warning::
@@ -308,7 +308,7 @@ class IBIS8542Model(ModelBase):
 
         time, row, column = spectrum_index if spectrum_index is not None else [None]*3
         fitted_parameters, success = self._curve_fit(model_with_impl, spectrum, guess, sigma, (min_bound, max_bound),
-                                                     x_scale, time=time, row=row, column=column)
+                                                     x_scale, time=time, row=row, column=column, **kwargs)
 
         chi2 = np.sum(((spectrum - model_with_impl(self.constant_wavelengths, *fitted_parameters)) / sigma) ** 2)
 

--- a/src/mcalf/profiles/voigt.py
+++ b/src/mcalf/profiles/voigt.py
@@ -2,6 +2,7 @@ import warnings
 
 import numpy as np
 from scipy.integrate import IntegrationWarning, quad, quad_vec
+from scipy.special import voigt_profile
 
 # Load the C library
 import ctypes
@@ -39,71 +40,108 @@ sqrt_pi = np.sqrt(np.pi)
 A, B, C, D = params
 
 
-__all__ = ['voigt_approx_nobg', 'voigt_approx', 'double_voigt_approx_nobg', 'double_voigt_approx',
+__all__ = ['voigt_integrate', 'voigt_faddeeva', 'voigt_mclean',
            'voigt_nobg', 'voigt', 'double_voigt_nobg', 'double_voigt']
 
 
-def voigt_approx_nobg(x, a, b, s, g):
-    """Voigt function (efficient approximation) with no background (Base approx. Voigt function).
+def voigt_integrate(x, s, g, clib=True, **kwargs):
+    """Voigt function implementation (calculated by integrating).
 
-    This is the base for all other approximated Voigt functions. Not implemented in any models yet as initial tests
-    exhibited slow convergence.
+    The default Voigt implementation.
 
     Parameters
     ----------
-    ${SINGLE_VOIGT}
+    x : numpy.ndarray
+        Wavelengths to evaluate Voigt function at.
+    s : float
+        Sigma (for Gaussian).
+    g : float
+        Gamma (for Lorentzian).
+    clib : bool, optional, default=True
+        Whether to use the complied C library or a slower Python version. If using the C library, the accuracy
+        of the integration is reduced to give the code a significant speed boost. Python version can be used when
+        speed is not a priority. Python version will remove deviations that are sometimes present around the wings
+        due to the reduced accuracy.
 
-    ${EXTRA_APPROX}
+    Returns
+    -------
+    result : numpy.ndarray, shape=`x.shape`
+        The value of the Voigt function here.
+
+    Notes
+    -----
+    More information on the Voigt function can be found here: https://en.wikipedia.org/wiki/Voigt_profile
+    """
+    # return a * voigt_profile(x - b, s, g)
+    warnings.filterwarnings("ignore", category=IntegrationWarning)
+    if clib and not_on_rtd:
+        i = [quad(cvoigt, -np.inf, np.inf, args=(v, s, g), epsabs=1.49e-1, epsrel=1.49e-4)[0] for v in x]
+    else:
+        i = quad_vec(lambda y: np.exp(-y**2 / (2 * s**2)) / (g**2 + (x - y)**2), -np.inf, np.inf, **rtd)[0]
+    const = g / (s * np.sqrt(2 * np.pi**3))
+    return const * np.array(i)
+
+
+def voigt_faddeeva(x, s, g, **kwargs):
+    """Voigt function implementation (Faddeeva).
+
+    Parameters
+    ----------
+    x : numpy.ndarray
+        Wavelengths to evaluate Voigt function at.
+    s : float
+        Sigma (for Gaussian).
+    g : float
+        Gamma (for Lorentzian).
+
+    Returns
+    -------
+    result : numpy.ndarray, shape=`x.shape`
+        The value of the Voigt function here.
+    """
+    return voigt_profile(x, s, g)
+
+
+def voigt_mclean(x, s, g, **kwargs):
+    """Voigt function implementation (efficient approximation).
+
+    Not implemented in any models yet as initial tests exhibited slow convergence.
+
+    Parameters
+    ----------
+    x : numpy.ndarray
+        Wavelengths to evaluate Voigt function at.
+    s : float
+        Sigma (for Gaussian).
+    g : float
+        Gamma (for Lorentzian).
+
+    Returns
+    -------
+    result : numpy.ndarray, shape=`x.shape`
+        The value of the Voigt function here.
+
+    Notes
+    -----
+    This algorithm is taken from A. B. McLean et al. [1]_.
+
+    References
+    ----------
+    .. [1] A. B. McLean, C. E. J. Mitchell and D. M. Swanston, "Implementation of an efficient analytical
+      approximation to the Voigt function for photoemission lineshape analysis," Journal of Electron Spectroscopy and
+      Related Phenomena, vol. 69, pp. 125-132, 1994. https://doi.org/10.1016/0368-2048(94)02189-7
     """
     fwhm_g = 2 * s * np.sqrt(2 * np.log(2))
     fwhm_l = 2 * g
-    xx = (x - b) * 2 * sqrt_ln2 / fwhm_g
+    xx = x * 2 * sqrt_ln2 / fwhm_g
     xx = xx[..., np.newaxis]
     yy = fwhm_l * sqrt_ln2 / fwhm_g
     yy = yy[..., np.newaxis]
     v = np.sum((C * (yy - A) + D * (xx - B)) / ((yy - A) ** 2 + (xx - B) ** 2), axis=-1)
-    return fwhm_l * a * sqrt_pi / fwhm_g * v
+    return fwhm_l * sqrt_pi / fwhm_g * v
 
 
-def voigt_approx(x, a, b, s, g, d):
-    """Voigt function (efficient approximation) with background.
-
-    Parameters
-    ----------
-    ${SINGLE_VOIGT}
-    ${BACKGROUND}
-
-    ${EXTRA_APPROX}
-    """
-    return voigt_approx_nobg(x, a, b, s, g) + d
-
-
-def double_voigt_approx_nobg(x, a1, b1, s1, g1, a2, b2, s2, g2):
-    """Double Voigt function (efficient approximation) with no background.
-
-    Parameters
-    ----------
-    ${DOUBLE_VOIGT}
-
-    ${EXTRA_APPROX}
-    """
-    return voigt_approx_nobg(x, a1, b1, s1, g1) + voigt_approx_nobg(x, a2, b2, s2, g2)
-
-
-def double_voigt_approx(x, a1, b1, s1, g1, a2, b2, s2, g2, d):
-    """Double Voigt function (efficient approximation) with background.
-
-    Parameters
-    ----------
-    ${DOUBLE_VOIGT}
-    ${BACKGROUND}
-
-    ${EXTRA_APPROX}
-    """
-    return voigt_approx_nobg(x, a1, b1, s1, g1) + voigt_approx_nobg(x, a2, b2, s2, g2) + d
-
-
-def voigt_nobg(x, a, b, s, g, clib=True):
+def voigt_nobg(x, a, b, s, g, impl=voigt_integrate, **kwargs):
     """Voigt function with no background (Base Voigt function).
 
     This is the base of all the other Voigt functions.
@@ -111,59 +149,48 @@ def voigt_nobg(x, a, b, s, g, clib=True):
     Parameters
     ----------
     ${SINGLE_VOIGT}
-    ${CLIB}
 
-    ${EXTRA_STD}
+    ${SEE_ALSO}
     """
-    warnings.filterwarnings("ignore", category=IntegrationWarning)
-    u = x - b
-    if clib and not_on_rtd:
-        i = [quad(cvoigt, -np.inf, np.inf, args=(v, s, g), epsabs=1.49e-1, epsrel=1.49e-4)[0] for v in u]
-    else:
-        i = quad_vec(lambda y: np.exp(-y**2 / (2 * s**2)) / (g**2 + (u - y)**2), -np.inf, np.inf, **rtd)[0]
-    const = g / (s * np.sqrt(2 * np.pi**3))
-    return a * const * np.array(i)
+    return a * impl(x - b, s, g, **kwargs)
 
 
-def voigt(x, a, b, s, g, d, clib=True):
+def voigt(x, a, b, s, g, d, **kwargs):
     """Voigt function with background.
 
     Parameters
     ----------
     ${SINGLE_VOIGT}
     ${BACKGROUND}
-    ${CLIB}
 
-    ${EXTRA_STD}
+    ${SEE_ALSO}
     """
-    return voigt_nobg(x, a, b, s, g, clib) + d
+    return voigt_nobg(x, a, b, s, g, **kwargs) + d
 
 
-def double_voigt_nobg(x, a1, b1, s1, g1, a2, b2, s2, g2, clib=True):
+def double_voigt_nobg(x, a1, b1, s1, g1, a2, b2, s2, g2, **kwargs):
     """Double Voigt function with no background.
 
     Parameters
     ----------
     ${DOUBLE_VOIGT}
-    ${CLIB}
 
-    ${EXTRA_STD}
+    ${SEE_ALSO}
     """
-    return voigt_nobg(x, a1, b1, s1, g1, clib) + voigt_nobg(x, a2, b2, s2, g2, clib)
+    return voigt_nobg(x, a1, b1, s1, g1, **kwargs) + voigt_nobg(x, a2, b2, s2, g2, **kwargs)
 
 
-def double_voigt(x, a1, b1, s1, g1, a2, b2, s2, g2, d, clib=True):
+def double_voigt(x, a1, b1, s1, g1, a2, b2, s2, g2, d, **kwargs):
     """Double Voigt function with background.
 
     Parameters
     ----------
     ${DOUBLE_VOIGT}
     ${BACKGROUND}
-    ${CLIB}
 
-    ${EXTRA_STD}
+    ${SEE_ALSO}
     """
-    return double_voigt_nobg(x, a1, b1, s1, g1, a2, b2, s2, g2, clib) + d
+    return double_voigt_nobg(x, a1, b1, s1, g1, a2, b2, s2, g2, **kwargs) + d
 
 
 # Define "Parameters" options
@@ -199,12 +226,6 @@ __double_voigt = __input_x + """
 __background = """
     d : float
         Background."""
-__clib = """
-    clib : bool, optional, default=True
-        Whether to use the complied C library or a slower Python version. If using the C library, the accuracy
-        of the integration is reduced to give the code a significant speed boost. Python version can be used when
-        speed is not a priority. Python version will remove deviations that are sometimes present around the wings
-        due to the reduced accuracy."""
 
 # Define "Returns"
 __returns = """
@@ -215,40 +236,15 @@ __returns = """
 
     """
 
-# Define "Notes" (and "References") section
-__notes_approx = """
-    Notes
-    -----
-    This algorithm is taken from A. B. McLean et al. [1]_.
-
-    References
-    ----------
-    .. [1] A. B. McLean, C. E. J. Mitchell and D. M. Swanston, "Implementation of an efficient analytical
-      approximation to the Voigt function for photoemission lineshape analysis," Journal of Electron Spectroscopy and
-      Related Phenomena, vol. 69, pp. 125-132, 1994. https://doi.org/10.1016/0368-2048(94)02189-7"""
-__notes_std = """
-    Notes
-    -----
-    More information on the Voigt function can be found here: https://en.wikipedia.org/wiki/Voigt_profile"""
-
-
 # Define special "See Also" options
-__see_also_approx = [
-    '    voigt_approx_nobg : Base approximated Voigt function with no background.',
-    '    voigt_approx : Approximated Voigt function with background added.',
-    '    double_voigt_approx_nobg : Two approximated Voigt functions added together.',
-    '    double_voigt_approx : Two approximated Voigt functions and a background added together.',
-]
-__see_also_std = [
+__see_also = [
     '    voigt_nobg : Base Voigt function with no background.',
     '    voigt : Voigt function with background added.',
     '    double_voigt_nobg : Two Voigt functions added together.',
     '    double_voigt : Two Voigt function and a background added together.',
 ]
 # Extract the function name for easy exclusion of item
-__see_also_approx = [(i.split(':')[0].strip(), i) for i in __see_also_approx]
-__see_also_std = [(i.split(':')[0].strip(), i) for i in __see_also_std]
-__see_also = __see_also_approx + __see_also_std
+__see_also = [(i.split(':')[0].strip(), i) for i in __see_also]
 
 
 def __rm_self(func, items):
@@ -257,36 +253,42 @@ def __rm_self(func, items):
     return 'See Also\n    --------\n    ' + '\n'.join(ret).lstrip() + '\n'
 
 
-def __extra_approx(func):
-    """Merge common approx functions sections."""
-    return __returns + __rm_self(func.__name__, __see_also) + __notes_approx  # noqa: F821
-
-
-def __extra_std(func):
+def __see_also_f(func):
     """Merge common standard functions sections."""
-    return __returns + __rm_self(func.__name__, __see_also_std) + __notes_std  # noqa: F821
+    return __returns + __rm_self(func.__name__, __see_also)
 
 
-for f in [voigt_approx_nobg, voigt_approx, double_voigt_approx_nobg, double_voigt_approx,
-          voigt_nobg, voigt, double_voigt_nobg, double_voigt]:
+for f in [voigt_nobg, voigt, double_voigt_nobg, double_voigt]:
     f.__doc__ = f.__doc__.replace('${SINGLE_VOIGT}', __single_voigt.lstrip())
     f.__doc__ = f.__doc__.replace('${DOUBLE_VOIGT}', __double_voigt.lstrip())
     f.__doc__ = f.__doc__.replace('${BACKGROUND}', __background.lstrip())
-    f.__doc__ = f.__doc__.replace('${CLIB}', __clib.lstrip())
-    f.__doc__ = f.__doc__.replace('${EXTRA_APPROX}', __extra_approx(f).lstrip())
-    f.__doc__ = f.__doc__.replace('${EXTRA_STD}', __extra_std(f).lstrip())
+    f.__doc__ = f.__doc__.replace('${SEE_ALSO}', __see_also_f(f).lstrip())
 
 del __input_x
 del __single_voigt
 del __double_voigt
 del __background
-del __clib
 del __returns
-del __notes_approx
-del __notes_std
-del __see_also_approx
-del __see_also_std
 del __see_also
 del __rm_self
-del __extra_approx
-del __extra_std
+del __see_also_f
+
+
+def voigt_approx_nobg(*args, **kwargs):
+    # For backwards compatibility
+    return voigt_nobg(*args, impl=voigt_mclean, **kwargs)
+
+
+def voigt_approx(*args, **kwargs):
+    # For backwards compatibility
+    return voigt(*args, impl=voigt_mclean, **kwargs)
+
+
+def double_voigt_approx_nobg(*args, **kwargs):
+    # For backwards compatibility
+    return double_voigt_nobg(*args, impl=voigt_mclean, **kwargs)
+
+
+def double_voigt_approx(*args, **kwargs):
+    # For backwards compatibility
+    return double_voigt(*args, impl=voigt_mclean, **kwargs)

--- a/src/mcalf/profiles/voigt.py
+++ b/src/mcalf/profiles/voigt.py
@@ -227,51 +227,37 @@ __background = """
     d : float
         Background."""
 
-# Define "Returns"
-__returns = """
+
+def __see_also(func):
+    """Return the "See Also" section with the current function removed."""
+    see_also = filter(lambda x: f" {func.__name__} " not in x, [
+        '    voigt_nobg : Base Voigt function with no background.',
+        '    voigt : Voigt function with background added.',
+        '    double_voigt_nobg : Two Voigt functions added together.',
+        '    double_voigt : Two Voigt function and a background added together.',
+    ])
+    return """
     Returns
     -------
     result : numpy.ndarray, shape=`x.shape`
         The value of the Voigt function here.
 
-    """
-
-# Define special "See Also" options
-__see_also = [
-    '    voigt_nobg : Base Voigt function with no background.',
-    '    voigt : Voigt function with background added.',
-    '    double_voigt_nobg : Two Voigt functions added together.',
-    '    double_voigt : Two Voigt function and a background added together.',
-]
-# Extract the function name for easy exclusion of item
-__see_also = [(i.split(':')[0].strip(), i) for i in __see_also]
-
-
-def __rm_self(func, items):
-    """Return the "See Also" section with the current function removed."""
-    ret = [i[1] for i in items if i[0] != func]
-    return 'See Also\n    --------\n    ' + '\n'.join(ret).lstrip() + '\n'
-
-
-def __see_also_f(func):
-    """Merge common standard functions sections."""
-    return __returns + __rm_self(func.__name__, __see_also)
+    See Also
+    --------
+    """ + "\n".join(see_also).lstrip()
 
 
 for f in [voigt_nobg, voigt, double_voigt_nobg, double_voigt]:
     f.__doc__ = f.__doc__.replace('${SINGLE_VOIGT}', __single_voigt.lstrip())
     f.__doc__ = f.__doc__.replace('${DOUBLE_VOIGT}', __double_voigt.lstrip())
     f.__doc__ = f.__doc__.replace('${BACKGROUND}', __background.lstrip())
-    f.__doc__ = f.__doc__.replace('${SEE_ALSO}', __see_also_f(f).lstrip())
+    f.__doc__ = f.__doc__.replace('${SEE_ALSO}', __see_also(f).lstrip())
 
 del __input_x
 del __single_voigt
 del __double_voigt
 del __background
-del __returns
 del __see_also
-del __rm_self
-del __see_also_f
 
 
 def voigt_approx_nobg(*args, **kwargs):

--- a/src/mcalf/tests/models/test_ibis.py
+++ b/src/mcalf/tests/models/test_ibis.py
@@ -696,3 +696,32 @@ def test_random_state():
 
     assert score_b == pytest.approx(score_a)
     assert score_b == pytest.approx(np.array([0.45, 0.35, 0.45, 0.45, 0.35]))
+
+
+def test_voigt_impl():
+
+    # Testing that the `impl` kwarg works as expected
+
+    # Initialise model
+    import mcalf.profiles.voigt
+    original_wavelengths = np.linspace(8541.5, 8542.6, 30)
+    model = IBIS8542Model(
+        original_wavelengths=original_wavelengths,
+        delta_lambda=0.09,
+        impl=mcalf.profiles.voigt.voigt_faddeeva,
+    )
+    assert model.impl is mcalf.profiles.voigt.voigt_faddeeva
+
+    model.get_spectra(spectrum=mcalf.profiles.voigt.voigt_faddeeva(original_wavelengths - 8542, 0.2, 0.2))
+
+    spectrum = -1000 * mcalf.profiles.voigt.voigt_faddeeva(original_wavelengths - 8542, 0.2, 0.2)
+    np.testing.assert_array_almost_equal(
+        spectrum[:6],
+        [-313.43205388, -361.18283187, -415.56342341, -476.43382313, -543.16950581, -614.56515795],
+    )
+
+    fit = model.fit_spectrum(spectrum, classifications=0)
+    assert fit.parameters[0] == pytest.approx(-1000.2087777465979)
+    assert fit.parameters[1] == pytest.approx(8542.)
+    assert fit.parameters[2] == pytest.approx(0.19986737018417303)
+    assert fit.parameters[3] == pytest.approx(0.20019316920526792)

--- a/src/mcalf/visualisation/spec.py
+++ b/src/mcalf/visualisation/spec.py
@@ -1,7 +1,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
-from mcalf.profiles.voigt import double_voigt, voigt
+from mcalf.profiles.voigt import double_voigt, voigt, voigt_integrate
 from mcalf.utils.plot import hide_existing_labels
 from mcalf.utils.spec import reinterpolate_spectrum
 
@@ -10,7 +10,7 @@ __all__ = ['plot_ibis8542', 'plot_spectrum']
 
 def plot_ibis8542(wavelengths, spectrum, fit=None, background=0,
                   sigma=None, sigma_scale=70,
-                  stationary_line_core=None,
+                  stationary_line_core=None, impl=voigt_integrate,
                   subtraction=False, separate=False,
                   show_intensity=True, show_legend=True, ax=None):
     """Plot an :class:`~mcalf.models.IBIS8542Model` fit.
@@ -37,6 +37,8 @@ def plot_ibis8542(wavelengths, spectrum, fit=None, background=0,
         A factor to multiply the error bars to change their prominence.
     stationary_line_core : float, optional, default=None
         If given, will show a dashed line at this wavelength.
+    impl : callable, optional, default=voigt_integrate
+        The Voigt implementation to use.
     subtraction : bool, optional, default=False
         Whether to plot the `spectrum` minus emission fit (if exists) instead.
     separate : bool, optional, default=False
@@ -92,7 +94,7 @@ def plot_ibis8542(wavelengths, spectrum, fit=None, background=0,
             subtraction = separate = False  # not possible, ignore request
 
     if subtraction:
-        spectrum = spectrum - voigt(wavelengths, *fit[4:], 0, clib=False)
+        spectrum = spectrum - voigt(wavelengths, *fit[4:], 0, impl=impl, clib=False)
         plot_settings['obs']['label'] = 'observation - emission'
         show_fit = show_sigma = None
 
@@ -110,19 +112,19 @@ def plot_ibis8542(wavelengths, spectrum, fit=None, background=0,
         if separate:  # Plot each component separately
 
             ax.plot(wavelengths,
-                    double_voigt(wavelengths, *fit, background, clib=False),
+                    double_voigt(wavelengths, *fit, background, impl=impl, clib=False),
                     **plot_settings['fit'])
             ax.plot(wavelengths,
-                    voigt(wavelengths, *fit[:4], background, clib=False),
+                    voigt(wavelengths, *fit[:4], background, impl=impl, clib=False),
                     **plot_settings['abs'])
             ax.plot(wavelengths,
-                    voigt(wavelengths, *fit[4:], 0, clib=False),
+                    voigt(wavelengths, *fit[4:], 0, impl=impl, clib=False),
                     **plot_settings['emi'])
 
         else:  # Plot a combined profile
 
             ax.plot(wavelengths,
-                    fit_function(wavelengths, *fit, background, clib=False),
+                    fit_function(wavelengths, *fit, background, impl=impl, clib=False),
                     **plot_settings['fit'])
 
         # Plot absorption line core


### PR DESCRIPTION
When initialising the IBIS8542Model, a `impl` kwarg can now be passed to specify the function used to evaluate the Voigt function. The Faddeeva Voigt function is also added, using the SciPy implementation, however, the default implementation remains the integration method such that the code is fully backwards compatible.

Also, additional kwargs passed to the `fit` method are now passed through to SciPy curve_fit, which allows for the least squares configuration to be changed with ease.