### PR TITLE
Change default Voigt implementation to `voigt_faddeeva`

### DIFF
--- a/src/mcalf/models/base.py
+++ b/src/mcalf/models/base.py
@@ -757,7 +757,7 @@ class ModelBase:
             If few spectra are being fitted, performance may decrease due to the overhead associated with splitting
             the evaluation over separate processes. If `n_pools` is not an integer greater than zero, it will fit
             the spectrum with a for loop.
-        **kwargs : dict, optional
+        **kwargs
             Extra keyword arguments to pass to :meth:`~mcalf.models.ModelBase._fit`.
 
         Returns
@@ -906,7 +906,7 @@ class ModelBase:
         ----------
         spectrum : numpy.ndarray, ndim=1
             The explicit spectrum.
-        **kwargs : dict, optional
+        **kwargs
             Extra keyword arguments to pass to :meth:`~mcalf.models.ModelBase.fit`.
 
         Returns

--- a/src/mcalf/models/ibis.py
+++ b/src/mcalf/models/ibis.py
@@ -348,7 +348,7 @@ class IBIS8542Model(ModelBase):
             Explicit sigma index or profile. See :meth:`~mcalf.models.IBIS8542Model._get_sigma` for details.
         stationary_line_core : float, optional, default=`stationary_line_core`
             The stationary line core wavelength to mark on the plot.
-        **kwargs : dict
+        **kwargs
             Other parameters used to adjust the plotting.
             See :func:`mcalf.visualisation.plot_ibis8542` for full details.
 

--- a/src/mcalf/models/ibis.py
+++ b/src/mcalf/models/ibis.py
@@ -6,7 +6,7 @@ from sklearn.neural_network import MLPClassifier
 
 from mcalf.models.base import BASE_ATTRIBUTES, BASE_PARAMETERS, ModelBase
 from mcalf.models.results import FitResult
-from mcalf.profiles.voigt import double_voigt_nobg, voigt_integrate, voigt_nobg
+from mcalf.profiles.voigt import double_voigt_nobg, voigt_faddeeva, voigt_nobg
 from mcalf.utils.collections import OrderedParameterDict, Parameter
 from mcalf.utils.misc import load_parameter, update_signature
 from mcalf.utils.spec import generate_sigma
@@ -43,7 +43,7 @@ class IBIS8542Model(ModelBase):
         ('absorption_x_scale', [1500, 0.2, 0.3, 0.5]),
         ('emission_x_scale', [1500, 0.2, 0.3, 0.5]),
         ('random_state', None),
-        ('impl', voigt_integrate),
+        ('impl', voigt_faddeeva),
     ])
 
     def __init__(self, **kwargs):
@@ -477,7 +477,7 @@ IBIS8542_DOCS = """
     random_state : int, numpy.random.RandomState, optional, default=None
         Determines random number generation for weights and bias initialisation of the default `neural_network`.
         Pass an int for reproducible results across multiple function calls.
-    impl : callable, optional, default=voigt_integrate
+    impl : callable, optional, default=voigt_faddeeva
         Voigt implementation to use."""
 
 # Form the docstring and do the replacements

--- a/src/mcalf/models/results.py
+++ b/src/mcalf/models/results.py
@@ -61,7 +61,7 @@ class FitResult:
         ----------
         model : child class of :class:`~mcalf.models.ModelBase`
             The model object to plot with.
-        **kwargs : dict
+        **kwargs
             See the `model.plot` method for more details.
         """
         model.plot(self, **kwargs)

--- a/src/mcalf/profiles/voigt.py
+++ b/src/mcalf/profiles/voigt.py
@@ -132,7 +132,7 @@ def voigt_mclean(x, s, g, **kwargs):
     return fwhm_l * sqrt_pi / fwhm_g * v
 
 
-def voigt_nobg(x, a, b, s, g, impl=voigt_integrate, **kwargs):
+def voigt_nobg(x, a, b, s, g, impl=voigt_faddeeva, **kwargs):
     """Voigt function with no background (Base Voigt function).
 
     This is the base of all the other Voigt functions.

--- a/src/mcalf/profiles/voigt.py
+++ b/src/mcalf/profiles/voigt.py
@@ -6,29 +6,20 @@ from scipy.special import voigt_profile
 
 # Load the C library
 import ctypes
-import os.path
 from pathlib import Path
 # # Commands to manually generate
 # gcc -Wall -fPIC -c voigt.c
 # gcc -shared -o libvoigt.so voigt.o
-dllabspath = Path(os.path.dirname(os.path.abspath(__file__)))  # Path to libraries directory
+dllabspath = Path(__file__).absolute().parent  # Path to libraries directory
 try:
     libfile = [str(i) for i in dllabspath.glob('ext_voigtlib.*.so')][0]  # Select first (and only) library
     lib = ctypes.CDLL(libfile)  # Load the library
     lib.func.restype = ctypes.c_double  # Specify the expected result type
     lib.func.argtypes = (ctypes.c_int, ctypes.c_double)  # Specify the type of the input parameters
     cvoigt = lib.func  # Create alias for the specific function used in functions below
+    CLIB_INSTALLED = True
 except IndexError:  # File does not exist
-    warnings.warn("Could not locate the external C library. Further use of `clib` will fail!")
-
-###
-# readthedocs.org does not support clib (force clib=False)
-import os  # noqa: E402
-not_on_rtd = os.environ.get('READTHEDOCS') != 'True'
-rtd = {}
-if not not_on_rtd:  # Reduce computation time (and accuracy) of no clib version
-    rtd = {'epsabs': 1.49e-1, 'epsrel': 1.49e-4}
-###
+    CLIB_INSTALLED = False
 
 # Parameters for `voigt_approx_nobg` and other approx. Voigt functions
 params = np.array([[-1.2150, -1.3509, -1.2150, -1.3509],
@@ -44,7 +35,7 @@ __all__ = ['voigt_integrate', 'voigt_faddeeva', 'voigt_mclean',
            'voigt_nobg', 'voigt', 'double_voigt_nobg', 'double_voigt']
 
 
-def voigt_integrate(x, s, g, clib=True, **kwargs):
+def voigt_integrate(x, s, g, clib=CLIB_INSTALLED, **kwargs):
     """Voigt function implementation (calculated by integrating).
 
     The default Voigt implementation.
@@ -61,7 +52,7 @@ def voigt_integrate(x, s, g, clib=True, **kwargs):
         Whether to use the complied C library or a slower Python version. If using the C library, the accuracy
         of the integration is reduced to give the code a significant speed boost. Python version can be used when
         speed is not a priority. Python version will remove deviations that are sometimes present around the wings
-        due to the reduced accuracy.
+        due to the reduced accuracy. If the C extensions is not installed, will default to false.
 
     Returns
     -------
@@ -74,10 +65,10 @@ def voigt_integrate(x, s, g, clib=True, **kwargs):
     """
     # return a * voigt_profile(x - b, s, g)
     warnings.filterwarnings("ignore", category=IntegrationWarning)
-    if clib and not_on_rtd:
+    if clib:
         i = [quad(cvoigt, -np.inf, np.inf, args=(v, s, g), epsabs=1.49e-1, epsrel=1.49e-4)[0] for v in x]
     else:
-        i = quad_vec(lambda y: np.exp(-y**2 / (2 * s**2)) / (g**2 + (x - y)**2), -np.inf, np.inf, **rtd)[0]
+        i = quad_vec(lambda y: np.exp(-y**2 / (2 * s**2)) / (g**2 + (x - y)**2), -np.inf, np.inf)[0]
     const = g / (s * np.sqrt(2 * np.pi**3))
     return const * np.array(i)
 

--- a/src/mcalf/utils/plot.py
+++ b/src/mcalf/utils/plot.py
@@ -173,7 +173,7 @@ def calculate_extent(shape, resolution, offset=(0, 0), ax=None, dimension=None, 
         A 2-tuple (x, y) or list [x, y] can instead be given to provide a different name
         for the x-axis and y-axis respectively.
         Defaults is equivalent to ``dimension=('x-axis', 'y-axis')``.
-    **kwargs : dict, optional
+    **kwargs
         Extra keyword arguments to pass to :func:`calculate_axis_extent`.
 
     Returns

--- a/src/mcalf/utils/smooth.py
+++ b/src/mcalf/utils/smooth.py
@@ -114,7 +114,7 @@ def smooth_cube(cube, mask, **kwargs):
         Cube of velocities with dimensions [time, row, column].
     mask : numpy.ndarray, ndim=2
         The mask to apply to the [row, column] at every time. Points that are 0 or false will be removed.
-    **kwargs : dict, optional
+    **kwargs
         Keyword arguments to pass to :func:`gaussian_kern_3d`.
 
     Returns

--- a/src/mcalf/visualisation/spec.py
+++ b/src/mcalf/visualisation/spec.py
@@ -1,7 +1,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
-from mcalf.profiles.voigt import double_voigt, voigt, voigt_integrate
+from mcalf.profiles.voigt import double_voigt, voigt, voigt_faddeeva
 from mcalf.utils.plot import hide_existing_labels
 from mcalf.utils.spec import reinterpolate_spectrum
 
@@ -10,7 +10,7 @@ __all__ = ['plot_ibis8542', 'plot_spectrum']
 
 def plot_ibis8542(wavelengths, spectrum, fit=None, background=0,
                   sigma=None, sigma_scale=70,
-                  stationary_line_core=None, impl=voigt_integrate,
+                  stationary_line_core=None, impl=voigt_faddeeva,
                   subtraction=False, separate=False,
                   show_intensity=True, show_legend=True, ax=None):
     """Plot an :class:`~mcalf.models.IBIS8542Model` fit.
@@ -37,7 +37,7 @@ def plot_ibis8542(wavelengths, spectrum, fit=None, background=0,
         A factor to multiply the error bars to change their prominence.
     stationary_line_core : float, optional, default=None
         If given, will show a dashed line at this wavelength.
-    impl : callable, optional, default=voigt_integrate
+    impl : callable, optional, default=voigt_faddeeva
         The Voigt implementation to use.
     subtraction : bool, optional, default=False
         Whether to plot the `spectrum` minus emission fit (if exists) instead.


### PR DESCRIPTION
This PR changes the default Voigt implementation from `voigt_integrate` to `voigt_faddeeva` because it is much more efficient and sufficiently accurate.