### PR TITLE
Publish pure Python wheels

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,3 +104,19 @@ stages:
           - wheels_cp3{8,9,10,11}-macosx_arm64
           - wheels_cp3{8,9,10,11}-manylinux*_x86_64
           - wheels_cp3{8,9,10,11}-win_amd64
+    - stage: ReleasePure
+      condition: or(succeeded(), eq(variables['Build.Reason'], 'Manual'))
+      variables:
+        MCALF_NO_EXTENSIONS: "1"
+      jobs:
+        - template: publish.yml@OpenAstronomy
+          parameters:
+            ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/v') }}:
+              pypi_connection_name: 'pypi_endpoint'
+              pypi_endpoint_name: 'mcalf'
+            libraries:
+              - libfftw3-dev
+            test_extras: "tests"
+            test_command: pytest --pyargs mcalf
+            targets:
+              - wheels_universal

--- a/setup.py
+++ b/setup.py
@@ -30,11 +30,18 @@ class CTypes(Extension):
     pass
 
 
-is_nt = '_nt' if os.name == 'nt' else ''
-
-setup(
-    use_scm_version={'write_to': os.path.join('src', 'mcalf', '_version.py')},
-    setup_requires=['setuptools_scm'],
-    ext_modules=[CTypes("mcalf.profiles.ext_voigtlib", ["cextern/voigt{}.c".format(is_nt)], py_limited_api=True)],
-    cmdclass={'build_ext': build_ext},
-)
+setup_kwargs = {
+    "use_scm_version": {"write_to": os.path.join("src", "mcalf", "_version.py")},
+    "setup_requires": ["setuptools_scm"],
+}
+if not os.getenv("MCALF_NO_EXTENSIONS"):
+    is_nt = '_nt' if os.name == 'nt' else ''
+    setup_kwargs["ext_modules"] = [
+        CTypes(
+            "mcalf.profiles.ext_voigtlib",
+            ["cextern/voigt{}.c".format(is_nt)],
+            py_limited_api=True
+        ),
+    ]
+    setup_kwargs["cmdclass"] = {'build_ext': build_ext}
+setup(**setup_kwargs)

--- a/src/mcalf/tests/models/test_ibis.py
+++ b/src/mcalf/tests/models/test_ibis.py
@@ -58,6 +58,8 @@ def test_default_parameters(model):
 
 
 def test_ibis8542model_basic():
+    if os.getenv("MCALF_NO_EXTENSIONS"):
+        pytest.skip("C extensions are disabled")
     # Will break if default parameters are changes in mcalf.models.IBIS8542Model
     wl = 1000.97
     x_orig = np.linspace(999.81, 1002.13, num=25)
@@ -446,6 +448,8 @@ def ibis8542model_spectra(ibis8542model_init):
 
 @pytest.fixture(scope='module')
 def ibis8542model_results(ibis8542model_spectra):
+    if os.getenv("MCALF_NO_EXTENSIONS"):
+        pytest.skip("C extensions are disabled")
 
     # Load model with random spectra loaded
     m, classifications = ibis8542model_spectra

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ envlist =
 
 [testenv]
 changedir = .tmp/{envname}
+passenv =
+    MCALF_NO_EXTENSIONS
 setenv =
     PYTEST_COMMAND = pytest -vvv -s -ra --pyargs mcalf --cov-report=xml --cov=mcalf --cov-config={toxinidir}/setup.cfg
 deps =


### PR DESCRIPTION
These wheels will be used on platforms which don’t have compiled wheels. If you need the compiled Voigt implementation on these platforms, install the sdist.